### PR TITLE
Add Husky and Lint-Staged

### DIFF
--- a/common.js
+++ b/common.js
@@ -6,18 +6,15 @@
  *
  */
 
-
-
-
 const endpoint = process.env.TEST_ENDPOINT;
-let ngsild = 'ngsi-ld/v1';
+let ngsild = "ngsi-ld/v1";
 
 // Just to test an old NGSIv2 endpoint
-if (process.env.FAKE_LD === 'yes') {
-  ngsild = 'v2';
+if (process.env.FAKE_LD === "yes") {
+  ngsild = "v2";
 }
 
-const testedResource = endpoint + '/' + ngsild;
+const testedResource = endpoint + "/" + ngsild;
 
 // Regular expression for matching the link header pointing to the JSON-LD @context
 const JSON_LD_CONTEXT_HEADER = /<.+>;\s+rel="http:\/\/www\.w3\.org\/ns\/json-ld#context";\s+type="application\/ld\+json"/;
@@ -25,15 +22,18 @@ const JSON_LD_CONTEXT_HEADER = /<.+>;\s+rel="http:\/\/www\.w3\.org\/ns\/json-ld#
 const JSON = /application\/json(;.*)?/;
 
 function assertCreated(response, id) {
-  expect(response).toHaveProperty('statusCode', 201);
-  expect(response.headers).toHaveProperty('location', '/' + ngsild + '/entities/' + id);
+  expect(response).toHaveProperty("statusCode", 201);
+  expect(response.headers).toHaveProperty(
+    "location",
+    "/" + ngsild + "/entities/" + id
+  );
 }
 
 function assertResponse(response, mimeType) {
   const mType = mimeType || JSON;
 
-  expect(response.response).toHaveProperty('statusCode', 200);
-  expect(response.response.headers['content-type']).toMatch(mType);
+  expect(response.response).toHaveProperty("statusCode", 200);
+  expect(response.response.headers["content-type"]).toMatch(mType);
 
   // response.response.headers['link'] =
   // '<http://json-ld.org/contexts/person.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"';
@@ -64,10 +64,10 @@ function assertNoResultsQuery(response, mimeType) {
 }
 
 function serializeParams(query) {
-  let out = '';
+  let out = "";
   Object.keys(query).forEach(function(key) {
-    out += key + '=' + encodeURIComponent(query[key]);
-    out += '&';
+    out += key + "=" + encodeURIComponent(query[key]);
+    out += "&";
   });
 
   return out.substring(0, out.length - 1);

--- a/common.js
+++ b/common.js
@@ -7,14 +7,14 @@
  */
 
 const endpoint = process.env.TEST_ENDPOINT;
-let ngsild = "ngsi-ld/v1";
+let ngsild = 'ngsi-ld/v1';
 
 // Just to test an old NGSIv2 endpoint
-if (process.env.FAKE_LD === "yes") {
-  ngsild = "v2";
+if (process.env.FAKE_LD === 'yes') {
+  ngsild = 'v2';
 }
 
-const testedResource = endpoint + "/" + ngsild;
+const testedResource = endpoint + '/' + ngsild;
 
 // Regular expression for matching the link header pointing to the JSON-LD @context
 const JSON_LD_CONTEXT_HEADER = /<.+>;\s+rel="http:\/\/www\.w3\.org\/ns\/json-ld#context";\s+type="application\/ld\+json"/;
@@ -22,18 +22,18 @@ const JSON_LD_CONTEXT_HEADER = /<.+>;\s+rel="http:\/\/www\.w3\.org\/ns\/json-ld#
 const JSON = /application\/json(;.*)?/;
 
 function assertCreated(response, id) {
-  expect(response).toHaveProperty("statusCode", 201);
+  expect(response).toHaveProperty('statusCode', 201);
   expect(response.headers).toHaveProperty(
-    "location",
-    "/" + ngsild + "/entities/" + id
+    'location',
+    '/' + ngsild + '/entities/' + id
   );
 }
 
 function assertResponse(response, mimeType) {
   const mType = mimeType || JSON;
 
-  expect(response.response).toHaveProperty("statusCode", 200);
-  expect(response.response.headers["content-type"]).toMatch(mType);
+  expect(response.response).toHaveProperty('statusCode', 200);
+  expect(response.response.headers['content-type']).toMatch(mType);
 
   // response.response.headers['link'] =
   // '<http://json-ld.org/contexts/person.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"';
@@ -64,10 +64,10 @@ function assertNoResultsQuery(response, mimeType) {
 }
 
 function serializeParams(query) {
-  let out = "";
+  let out = '';
   Object.keys(query).forEach(function(key) {
-    out += key + "=" + encodeURIComponent(query[key]);
-    out += "&";
+    out += key + '=' + encodeURIComponent(query[key]);
+    out += '&';
   });
 
   return out.substring(0, out.length - 1);

--- a/contextConsumption/query_entities_test.js
+++ b/contextConsumption/query_entities_test.js
@@ -1,136 +1,149 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
+const assertRetrievedQuery = require("../common.js").assertRetrievedQuery;
+const serializeParams = require("../common.js").serializeParams;
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-const assertRetrievedQuery = require('../common.js').assertRetrievedQuery;
-const serializeParams = require('../common.js').serializeParams;
-
-describe('Query Entity. JSON. Default @context', () => {
+describe("Query Entity. JSON. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T_Query:EntityForQuery2345',
-    'type': 'T_Query',
-    'P100': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T_Query:EntityForQuery2345",
+    type: "T_Query",
+    P100: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     },
-    'R100': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789',
-      'R1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T3:A2345'
+    R100: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789",
+      R1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T3:A2345"
       },
-      'R1_P1': {
-        'type': 'Property',
-        'value': false
+      R1_P1: {
+        type: "Property",
+        value: false
       }
     },
-    'location': {
-      'type': 'GeoProperty',
-      'value': {
-        'type': 'Point',
-        'coordinates': [-30.01, 75.01]
+    location: {
+      type: "GeoProperty",
+      value: {
+        type: "Point",
+        coordinates: [-30.01, 75.01]
       }
     }
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-   
-  it('query by type', async function() {
+
+  it("query by type", async function() {
     const queryParams = {
-      type: 'T_Query',
+      type: "T_Query"
     };
-            
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
-    assertRetrievedQuery(response,entity); 
-  });
-   
-  it('query by id', async function() {
-    const queryParams = {
-      id: entity.id  
-    };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
-    assertRetrievedQuery(response,entity);
-  });
-    
-  it('query by idPattern', async function() {
-    const queryParams = {
-      idPattern: '.*:T_Query:EntityForQuery.*'
-    };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
     assertRetrievedQuery(response, entity);
   });
-    
-  it('query by condition over value', async function() {
+
+  it("query by id", async function() {
     const queryParams = {
-      id: entity.id,  
-      q: 'P100>5'  
+      id: entity.id
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
     assertRetrievedQuery(response, entity);
   });
-    
-  it('query by condition over object', async function() {
+
+  it("query by idPattern", async function() {
+    const queryParams = {
+      idPattern: ".*:T_Query:EntityForQuery.*"
+    };
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
+    assertRetrievedQuery(response, entity);
+  });
+
+  it("query by condition over value", async function() {
+    const queryParams = {
+      id: entity.id,
+      q: "P100>5"
+    };
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
+    assertRetrievedQuery(response, entity);
+  });
+
+  it("query by condition over object", async function() {
     const queryParams = {
       id: entity.id,
       q: 'R100=="urn:ngsi-ld:T2:6789"'
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
-    assertRetrievedQuery(response, entity);
-  });
-    
-  it('query by condition over observedAt', async function() {
-    const queryParams = {
-      id: entity.id,
-      q: 'P100.observedAt>2018-12-03'
-    };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
-    assertRetrievedQuery(response, entity);
-  });
-    
-  it('query by condition over property of property', async function() {
-    const queryParams = {
-      id: entity.id,
-      q: 'P100.P1_P1 > 0.70'
-    };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
     assertRetrievedQuery(response, entity);
   });
 
-  it('geoQuery near', async function() {
+  it("query by condition over observedAt", async function() {
     const queryParams = {
-      geometry: 'Point',
-      coordinates: '[-30,75]',
-      georel: 'near;maxDistance==3000'
+      id: entity.id,
+      q: "P100.observedAt>2018-12-03"
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
     assertRetrievedQuery(response, entity);
   });
-  
+
+  it("query by condition over property of property", async function() {
+    const queryParams = {
+      id: entity.id,
+      q: "P100.P1_P1 > 0.70"
+    };
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
+    assertRetrievedQuery(response, entity);
+  });
+
+  it("geoQuery near", async function() {
+    const queryParams = {
+      geometry: "Point",
+      coordinates: "[-30,75]",
+      georel: "near;maxDistance==3000"
+    };
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams)
+    );
+    assertRetrievedQuery(response, entity);
+  });
 });

--- a/contextConsumption/query_entities_test.js
+++ b/contextConsumption/query_entities_test.js
@@ -1,43 +1,43 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
-const assertRetrievedQuery = require("../common.js").assertRetrievedQuery;
-const serializeParams = require("../common.js").serializeParams;
+const entitiesResource = testedResource + '/entities/';
+const assertRetrievedQuery = require('../common.js').assertRetrievedQuery;
+const serializeParams = require('../common.js').serializeParams;
 
-describe("Query Entity. JSON. Default @context", () => {
+describe('Query Entity. JSON. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T_Query:EntityForQuery2345",
-    type: "T_Query",
+    id: 'urn:ngsi-ld:T_Query:EntityForQuery2345',
+    type: 'T_Query',
     P100: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00",
+      observedAt: '2018-12-04T12:00:00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     },
     R100: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789",
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789',
       R1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T3:A2345"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T3:A2345'
       },
       R1_P1: {
-        type: "Property",
+        type: 'Property',
         value: false
       }
     },
     location: {
-      type: "GeoProperty",
+      type: 'GeoProperty',
       value: {
-        type: "Point",
+        type: 'Point',
         coordinates: [-30.01, 75.01]
       }
     }
@@ -53,96 +53,96 @@ describe("Query Entity. JSON. Default @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("query by type", async function() {
+  it('query by type', async function() {
     const queryParams = {
-      type: "T_Query"
+      type: 'T_Query'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by id", async function() {
+  it('query by id', async function() {
     const queryParams = {
       id: entity.id
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by idPattern", async function() {
+  it('query by idPattern', async function() {
     const queryParams = {
-      idPattern: ".*:T_Query:EntityForQuery.*"
+      idPattern: '.*:T_Query:EntityForQuery.*'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by condition over value", async function() {
+  it('query by condition over value', async function() {
     const queryParams = {
       id: entity.id,
-      q: "P100>5"
+      q: 'P100>5'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by condition over object", async function() {
+  it('query by condition over object', async function() {
     const queryParams = {
       id: entity.id,
       q: 'R100=="urn:ngsi-ld:T2:6789"'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by condition over observedAt", async function() {
+  it('query by condition over observedAt', async function() {
     const queryParams = {
       id: entity.id,
-      q: "P100.observedAt>2018-12-03"
+      q: 'P100.observedAt>2018-12-03'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("query by condition over property of property", async function() {
+  it('query by condition over property of property', async function() {
     const queryParams = {
       id: entity.id,
-      q: "P100.P1_P1 > 0.70"
+      q: 'P100.P1_P1 > 0.70'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });
 
-  it("geoQuery near", async function() {
+  it('geoQuery near', async function() {
     const queryParams = {
-      geometry: "Point",
-      coordinates: "[-30,75]",
-      georel: "near;maxDistance==3000"
+      geometry: 'Point',
+      coordinates: '[-30,75]',
+      georel: 'near;maxDistance==3000'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams)
+      entitiesResource + '?' + serializeParams(queryParams)
     );
     assertRetrievedQuery(response, entity);
   });

--- a/contextConsumption/query_entities_with_ld_context_test.js
+++ b/contextConsumption/query_entities_with_ld_context_test.js
@@ -1,10 +1,10 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
-const assertRetrievedQuery = require("../common.js").assertRetrievedQuery;
-const assertNoResultsQuery = require("../common.js").assertNoResultsQuery;
-const serializeParams = require("../common.js").serializeParams;
+const entitiesResource = testedResource + '/entities/';
+const assertRetrievedQuery = require('../common.js').assertRetrievedQuery;
+const assertNoResultsQuery = require('../common.js').assertNoResultsQuery;
+const serializeParams = require('../common.js').serializeParams;
 
 const JSON_LD = /application\/ld\+json(;.*)?/;
 
@@ -12,30 +12,30 @@ const JSON_LD_HEADER_CONTEXT =
   '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"';
 
 const ACCEPT_JSON_LD = {
-  Accept: "application/ld+json"
+  Accept: 'application/ld+json'
 };
 
-describe("Query Entity. JSON-LD. @context", () => {
+describe('Query Entity. JSON-LD. @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:I123k467:Context",
-    type: "T_Query",
+    id: 'urn:ngsi-ld:T:I123k467:Context',
+    type: 'T_Query',
     P100: {
-      type: "Property",
+      type: 'Property',
       value: 12
     },
     R100: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789"
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789'
     },
-    "@context":
-      "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+    '@context':
+      'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
   };
 
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     const JSON_LD_HEADERS = {
-      "Content-Type": "application/ld+json"
+      'Content-Type': 'application/ld+json'
     };
     return http.post(entitiesResource, entity, JSON_LD_HEADERS);
   });
@@ -44,61 +44,61 @@ describe("Query Entity. JSON-LD. @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("query by type. Default @context. Not found as @context does not match.", async function() {
+  it('query by type. Default @context. Not found as @context does not match.', async function() {
     const queryParams = {
-      type: "T_Query"
+      type: 'T_Query'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams),
+      entitiesResource + '?' + serializeParams(queryParams),
       ACCEPT_JSON_LD
     );
     assertNoResultsQuery(response, JSON_LD);
   });
 
-  it("query by type. Right @context", async function() {
+  it('query by type. Right @context', async function() {
     const queryParams = {
-      type: "T_Query"
+      type: 'T_Query'
     };
 
     const headers = {
-      Accept: "application/ld+json",
+      Accept: 'application/ld+json',
       Link: JSON_LD_HEADER_CONTEXT
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams),
+      entitiesResource + '?' + serializeParams(queryParams),
       headers
     );
     assertRetrievedQuery(response, entity, JSON_LD);
   });
 
-  it("query by condition over value. Default @context. Not found as @context does not match for the attribute.", async function() {
+  it('query by condition over value. Default @context. Not found as @context does not match for the attribute.', async function() {
     const queryParams = {
-      q: "P100>5"
+      q: 'P100>5'
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams),
+      entitiesResource + '?' + serializeParams(queryParams),
       ACCEPT_JSON_LD
     );
     // Response here shall be JSON
     assertNoResultsQuery(response, JSON_LD);
   });
 
-  it("query by condition over value. Right @context. ", async function() {
+  it('query by condition over value. Right @context. ', async function() {
     const queryParams = {
       id: entity.id,
-      q: "P100>5"
+      q: 'P100>5'
     };
 
     const headers = {
-      Accept: "application/ld+json",
+      Accept: 'application/ld+json',
       Link: JSON_LD_HEADER_CONTEXT
     };
 
     const response = await http.get(
-      entitiesResource + "?" + serializeParams(queryParams),
+      entitiesResource + '?' + serializeParams(queryParams),
       headers
     );
     assertRetrievedQuery(response, entity, JSON_LD);

--- a/contextConsumption/query_entities_with_ld_context_test.js
+++ b/contextConsumption/query_entities_with_ld_context_test.js
@@ -1,95 +1,106 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
-
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-const assertRetrievedQuery = require('../common.js').assertRetrievedQuery;
-const assertNoResultsQuery = require('../common.js').assertNoResultsQuery;
-const serializeParams = require('../common.js').serializeParams;
+const entitiesResource = testedResource + "/entities/";
+const assertRetrievedQuery = require("../common.js").assertRetrievedQuery;
+const assertNoResultsQuery = require("../common.js").assertNoResultsQuery;
+const serializeParams = require("../common.js").serializeParams;
 
 const JSON_LD = /application\/ld\+json(;.*)?/;
 
-const JSON_LD_HEADER_CONTEXT = '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"';
+const JSON_LD_HEADER_CONTEXT =
+  '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"';
 
 const ACCEPT_JSON_LD = {
-  'Accept': 'application/ld+json'
+  Accept: "application/ld+json"
 };
 
-describe('Query Entity. JSON-LD. @context', () => {
+describe("Query Entity. JSON-LD. @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:I123k467:Context',
-    'type': 'T_Query',
-    'P100': {
-      'type': 'Property',
-      'value': 12,
+    id: "urn:ngsi-ld:T:I123k467:Context",
+    type: "T_Query",
+    P100: {
+      type: "Property",
+      value: 12
     },
-    'R100': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789',
+    R100: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789"
     },
-    '@context': 'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
+    "@context":
+      "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     const JSON_LD_HEADERS = {
-      'Content-Type': 'application/ld+json'
+      "Content-Type": "application/ld+json"
     };
     return http.post(entitiesResource, entity, JSON_LD_HEADERS);
   });
-    
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-    
-  it('query by type. Default @context. Not found as @context does not match.', async function() {
+
+  it("query by type. Default @context. Not found as @context does not match.", async function() {
     const queryParams = {
-      type: 'T_Query',
+      type: "T_Query"
     };
-            
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams), ACCEPT_JSON_LD);
-    assertNoResultsQuery(response,JSON_LD); 
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams),
+      ACCEPT_JSON_LD
+    );
+    assertNoResultsQuery(response, JSON_LD);
   });
-    
-  it('query by type. Right @context', async function() {
+
+  it("query by type. Right @context", async function() {
     const queryParams = {
-      type: 'T_Query',
+      type: "T_Query"
     };
-        
+
     const headers = {
-      'Accept': 'application/ld+json',
-      'Link': JSON_LD_HEADER_CONTEXT
+      Accept: "application/ld+json",
+      Link: JSON_LD_HEADER_CONTEXT
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams), headers);
-    assertRetrievedQuery(response,entity,JSON_LD); 
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams),
+      headers
+    );
+    assertRetrievedQuery(response, entity, JSON_LD);
   });
-    
-  it('query by condition over value. Default @context. Not found as @context does not match for the attribute.', async function() {
+
+  it("query by condition over value. Default @context. Not found as @context does not match for the attribute.", async function() {
     const queryParams = {
-      q: 'P100>5'  
+      q: "P100>5"
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams), ACCEPT_JSON_LD);
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams),
+      ACCEPT_JSON_LD
+    );
     // Response here shall be JSON
     assertNoResultsQuery(response, JSON_LD);
   });
-    
-  it('query by condition over value. Right @context. ', async function() {
+
+  it("query by condition over value. Right @context. ", async function() {
     const queryParams = {
-      id: entity.id,  
-      q: 'P100>5'  
+      id: entity.id,
+      q: "P100>5"
     };
-        
+
     const headers = {
-      'Accept': 'application/ld+json',
-      'Link': JSON_LD_HEADER_CONTEXT
+      Accept: "application/ld+json",
+      Link: JSON_LD_HEADER_CONTEXT
     };
-        
-    const response = await http.get(entitiesResource + '?' + serializeParams(queryParams), headers);
+
+    const response = await http.get(
+      entitiesResource + "?" + serializeParams(queryParams),
+      headers
+    );
     assertRetrievedQuery(response, entity, JSON_LD);
   });
-  
 });

--- a/contextConsumption/retrieve_entity_test.js
+++ b/contextConsumption/retrieve_entity_test.js
@@ -1,95 +1,98 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
+const assertRetrieved = require("../common.js").assertRetrieved;
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-const assertRetrieved = require('../common.js').assertRetrieved;
-
-describe('Retrieve Entity. JSON. Default @context', () => {
+describe("Retrieve Entity. JSON. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     },
-    'R1': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789',
-      'R1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T3:A2345'
+    R1: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789",
+      R1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T3:A2345"
       },
-      'R1_P1': {
-        'type': 'Property',
-        'value': false
+      R1_P1: {
+        type: "Property",
+        value: false
       }
     }
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   // Entity key Values
   const entityKeyValues = {
-    'id': entity.id,
-    'type': entity.type,
-    'P1': entity.P1.value,
-    'R1': entity.R1.object
+    id: entity.id,
+    type: entity.type,
+    P1: entity.P1.value,
+    R1: entity.R1.object
   };
 
   // Entity projection only one attribute
   const entityOneAttr = {
-    'id': entity.id,
-    'type': entity.type,
-    'P1': entity.P1
+    id: entity.id,
+    type: entity.type,
+    P1: entity.P1
   };
 
   const entityNoAttr = {
-    'id': entity.id,
-    'type': entity.type,
+    id: entity.id,
+    type: entity.type
   };
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-  
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-    
-  it('should retrieve the entity', async function() {
+
+  it("should retrieve the entity", async function() {
     const response = await http.get(entitiesResource + entityId);
-    assertRetrieved(response,entity);
+    assertRetrieved(response, entity);
   });
-    
-  it('should retrieve the entity key values mode', async function() {
-    const response = await http.get(entitiesResource + entityId + '?options=keyValues');
-    assertRetrieved(response,entityKeyValues);
+
+  it("should retrieve the entity key values mode", async function() {
+    const response = await http.get(
+      entitiesResource + entityId + "?options=keyValues"
+    );
+    assertRetrieved(response, entityKeyValues);
   });
-    
-  it('should retrieve the entity attribute projection', async function() {
-    const response = await http.get(entitiesResource + entityId + '?attrs=P1');
+
+  it("should retrieve the entity attribute projection", async function() {
+    const response = await http.get(entitiesResource + entityId + "?attrs=P1");
     assertRetrieved(response, entityOneAttr);
   });
-    
-  it('should retrieve the entity no attribute matches', async function() {
-    const response = await http.get(entitiesResource + entityId + '?attrs=notFoundAttr');
-    assertRetrieved(response,entityNoAttr);
+
+  it("should retrieve the entity no attribute matches", async function() {
+    const response = await http.get(
+      entitiesResource + entityId + "?attrs=notFoundAttr"
+    );
+    assertRetrieved(response, entityNoAttr);
   });
-    
-  it('should report an error if the entity does not exist', async function() {
-    const response = await http.get(entitiesResource + encodeURIComponent('urn:ngsi-ld:xxxxxxx'));
-    expect(response.response).toHaveProperty('statusCode', 404);
+
+  it("should report an error if the entity does not exist", async function() {
+    const response = await http.get(
+      entitiesResource + encodeURIComponent("urn:ngsi-ld:xxxxxxx")
+    );
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-  
 });

--- a/contextConsumption/retrieve_entity_test.js
+++ b/contextConsumption/retrieve_entity_test.js
@@ -1,35 +1,35 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
-const assertRetrieved = require("../common.js").assertRetrieved;
+const entitiesResource = testedResource + '/entities/';
+const assertRetrieved = require('../common.js').assertRetrieved;
 
-describe("Retrieve Entity. JSON. Default @context", () => {
+describe('Retrieve Entity. JSON. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00",
+      observedAt: '2018-12-04T12:00:00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     },
     R1: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789",
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789',
       R1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T3:A2345"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T3:A2345'
       },
       R1_P1: {
-        type: "Property",
+        type: 'Property',
         value: false
       }
     }
@@ -65,34 +65,34 @@ describe("Retrieve Entity. JSON. Default @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("should retrieve the entity", async function() {
+  it('should retrieve the entity', async function() {
     const response = await http.get(entitiesResource + entityId);
     assertRetrieved(response, entity);
   });
 
-  it("should retrieve the entity key values mode", async function() {
+  it('should retrieve the entity key values mode', async function() {
     const response = await http.get(
-      entitiesResource + entityId + "?options=keyValues"
+      entitiesResource + entityId + '?options=keyValues'
     );
     assertRetrieved(response, entityKeyValues);
   });
 
-  it("should retrieve the entity attribute projection", async function() {
-    const response = await http.get(entitiesResource + entityId + "?attrs=P1");
+  it('should retrieve the entity attribute projection', async function() {
+    const response = await http.get(entitiesResource + entityId + '?attrs=P1');
     assertRetrieved(response, entityOneAttr);
   });
 
-  it("should retrieve the entity no attribute matches", async function() {
+  it('should retrieve the entity no attribute matches', async function() {
     const response = await http.get(
-      entitiesResource + entityId + "?attrs=notFoundAttr"
+      entitiesResource + entityId + '?attrs=notFoundAttr'
     );
     assertRetrieved(response, entityNoAttr);
   });
 
-  it("should report an error if the entity does not exist", async function() {
+  it('should report an error if the entity does not exist', async function() {
     const response = await http.get(
-      entitiesResource + encodeURIComponent("urn:ngsi-ld:xxxxxxx")
+      entitiesResource + encodeURIComponent('urn:ngsi-ld:xxxxxxx')
     );
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 });

--- a/contextConsumption/retrieve_entity_with_ldcontext_test.js
+++ b/contextConsumption/retrieve_entity_with_ldcontext_test.js
@@ -1,50 +1,50 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
-const assertRetrieved = require("../common.js").assertRetrieved;
+const entitiesResource = testedResource + '/entities/';
+const assertRetrieved = require('../common.js').assertRetrieved;
 
 const JSON_LD = /application\/ld\+json(;.*)?/;
 
 const JSON_LD_HEADERS_POST = {
-  "Content-Type": "application/ld+json"
+  'Content-Type': 'application/ld+json'
 };
 
 const JSON_LD_HEADERS_GET = {
-  Accept: "application/ld+json"
+  Accept: 'application/ld+json'
 };
 
-describe("Retrieve Entity. JSON-LD. @context ", () => {
+describe('Retrieve Entity. JSON-LD. @context ', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00",
+      observedAt: '2018-12-04T12:00:00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     },
     R1: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789",
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789',
       R1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T3:A2345"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T3:A2345'
       },
       R1_P1: {
-        type: "Property",
+        type: 'Property',
         value: false
       }
     },
-    "@context":
-      "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+    '@context':
+      'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
   };
 
   const entityId = encodeURIComponent(entity.id);
@@ -55,7 +55,7 @@ describe("Retrieve Entity. JSON-LD. @context ", () => {
     type: entity.type,
     P1: entity.P1.value,
     R1: entity.R1.object,
-    "@context": entity["@context"]
+    '@context': entity['@context']
   };
 
   // Entity projection only one attribute
@@ -63,13 +63,13 @@ describe("Retrieve Entity. JSON-LD. @context ", () => {
     id: entity.id,
     type: entity.type,
     P1: entity.P1,
-    "@context": entity["@context"]
+    '@context': entity['@context']
   };
 
   const entityNoAttr = {
     id: entity.id,
     type: entity.type,
-    "@context": entity["@context"]
+    '@context': entity['@context']
   };
 
   beforeAll(() => {
@@ -80,7 +80,7 @@ describe("Retrieve Entity. JSON-LD. @context ", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("should retrieve the entity. JSON-LD MIME Type requested", async function() {
+  it('should retrieve the entity. JSON-LD MIME Type requested', async function() {
     const response = await http.get(
       entitiesResource + entityId,
       JSON_LD_HEADERS_GET
@@ -88,54 +88,54 @@ describe("Retrieve Entity. JSON-LD. @context ", () => {
     assertRetrieved(response, entity, JSON_LD);
   });
 
-  it("should retrieve the entity. JSON MIME type (default)", async function() {
+  it('should retrieve the entity. JSON MIME type (default)', async function() {
     const response = await http.get(entitiesResource + entityId);
     assertRetrieved(response, entity);
   });
 
-  it("should retrieve the entity key values mode", async function() {
+  it('should retrieve the entity key values mode', async function() {
     const response = await http.get(
-      entitiesResource + entityId + "?options=keyValues",
+      entitiesResource + entityId + '?options=keyValues',
       JSON_LD_HEADERS_GET
     );
     assertRetrieved(response, entityKeyValues, JSON_LD);
   });
 
-  it("should retrieve the entity attribute projection", async function() {
+  it('should retrieve the entity attribute projection', async function() {
     const headers = {
-      Accept: "application/ld+json",
+      Accept: 'application/ld+json',
       Link:
         '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
     const response = await http.get(
-      entitiesResource + entityId + "?attrs=P1",
+      entitiesResource + entityId + '?attrs=P1',
       headers
     );
     assertRetrieved(response, entityOneAttr, JSON_LD);
   });
 
-  it("should retrieve the entity no attribute matches", async function() {
+  it('should retrieve the entity no attribute matches', async function() {
     const headers = {
-      Accept: "application/ld+json",
+      Accept: 'application/ld+json',
       Link:
         '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
     const response = await http.get(
-      entitiesResource + entityId + "?attrs=notFoundAttr",
+      entitiesResource + entityId + '?attrs=notFoundAttr',
       headers
     );
     assertRetrieved(response, entityNoAttr, JSON_LD);
   });
 
-  it("should retrieve the entity no attribute matches as @context differs", async function() {
+  it('should retrieve the entity no attribute matches as @context differs', async function() {
     const headers = {
-      Accept: "application/ld+json",
+      Accept: 'application/ld+json',
       // Observe that the provided @context will make the attribute not to match
       Link:
         '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
     const response = await http.get(
-      entitiesResource + entityId + "?attrs=P1",
+      entitiesResource + entityId + '?attrs=P1',
       headers
     );
     assertRetrieved(response, entityNoAttr, JSON_LD);

--- a/contextConsumption/retrieve_entity_with_ldcontext_test.js
+++ b/contextConsumption/retrieve_entity_with_ldcontext_test.js
@@ -1,127 +1,143 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
-
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-const assertRetrieved = require('../common.js').assertRetrieved;
+const entitiesResource = testedResource + "/entities/";
+const assertRetrieved = require("../common.js").assertRetrieved;
 
 const JSON_LD = /application\/ld\+json(;.*)?/;
 
 const JSON_LD_HEADERS_POST = {
-  'Content-Type': 'application/ld+json'
+  "Content-Type": "application/ld+json"
 };
 
 const JSON_LD_HEADERS_GET = {
-  'Accept': 'application/ld+json'
+  Accept: "application/ld+json"
 };
 
-describe('Retrieve Entity. JSON-LD. @context ', () => {
+describe("Retrieve Entity. JSON-LD. @context ", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     },
-    'R1': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789',
-      'R1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T3:A2345'
+    R1: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789",
+      R1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T3:A2345"
       },
-      'R1_P1': {
-        'type': 'Property',
-        'value': false
+      R1_P1: {
+        type: "Property",
+        value: false
       }
     },
-    '@context': 'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
+    "@context":
+      "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   // Entity key Values
   const entityKeyValues = {
-    'id': entity.id,
-    'type': entity.type,
-    'P1': entity.P1.value,
-    'R1': entity.R1.object,
-    '@context': entity['@context']
+    id: entity.id,
+    type: entity.type,
+    P1: entity.P1.value,
+    R1: entity.R1.object,
+    "@context": entity["@context"]
   };
 
   // Entity projection only one attribute
   const entityOneAttr = {
-    'id': entity.id,
-    'type': entity.type,
-    'P1': entity.P1,
-    '@context': entity['@context']
+    id: entity.id,
+    type: entity.type,
+    P1: entity.P1,
+    "@context": entity["@context"]
   };
 
   const entityNoAttr = {
-    'id': entity.id,
-    'type': entity.type,
-    '@context': entity['@context']
+    id: entity.id,
+    type: entity.type,
+    "@context": entity["@context"]
   };
 
   beforeAll(() => {
     return http.post(entitiesResource, entity, JSON_LD_HEADERS_POST);
   });
-  
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-  
-  it('should retrieve the entity. JSON-LD MIME Type requested', async function() {
-    const response = await http.get(entitiesResource + entityId, JSON_LD_HEADERS_GET);
-    assertRetrieved(response,entity, JSON_LD);
+
+  it("should retrieve the entity. JSON-LD MIME Type requested", async function() {
+    const response = await http.get(
+      entitiesResource + entityId,
+      JSON_LD_HEADERS_GET
+    );
+    assertRetrieved(response, entity, JSON_LD);
   });
-    
-  it('should retrieve the entity. JSON MIME type (default)', async function() {
+
+  it("should retrieve the entity. JSON MIME type (default)", async function() {
     const response = await http.get(entitiesResource + entityId);
-    assertRetrieved(response,entity);
+    assertRetrieved(response, entity);
   });
-    
-  it('should retrieve the entity key values mode', async function() {
-    const response = await http.get(entitiesResource + entityId + '?options=keyValues', JSON_LD_HEADERS_GET);
-    assertRetrieved(response,entityKeyValues,JSON_LD);
+
+  it("should retrieve the entity key values mode", async function() {
+    const response = await http.get(
+      entitiesResource + entityId + "?options=keyValues",
+      JSON_LD_HEADERS_GET
+    );
+    assertRetrieved(response, entityKeyValues, JSON_LD);
   });
-    
-  it('should retrieve the entity attribute projection', async function() {
+
+  it("should retrieve the entity attribute projection", async function() {
     const headers = {
-      'Accept': 'application/ld+json',
-      'Link': '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+      Accept: "application/ld+json",
+      Link:
+        '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
-    const response = await http.get(entitiesResource + entityId + '?attrs=P1', headers);
-    assertRetrieved(response,entityOneAttr, JSON_LD);
+    const response = await http.get(
+      entitiesResource + entityId + "?attrs=P1",
+      headers
+    );
+    assertRetrieved(response, entityOneAttr, JSON_LD);
   });
-    
-  it('should retrieve the entity no attribute matches', async function() {
+
+  it("should retrieve the entity no attribute matches", async function() {
     const headers = {
-      'Accept': 'application/ld+json',
-      'Link': '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+      Accept: "application/ld+json",
+      Link:
+        '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
-    const response = await http.get(entitiesResource + entityId + '?attrs=notFoundAttr', headers);
+    const response = await http.get(
+      entitiesResource + entityId + "?attrs=notFoundAttr",
+      headers
+    );
     assertRetrieved(response, entityNoAttr, JSON_LD);
   });
 
-  it('should retrieve the entity no attribute matches as @context differs', async function() {
+  it("should retrieve the entity no attribute matches as @context differs", async function() {
     const headers = {
-      'Accept': 'application/ld+json',
+      Accept: "application/ld+json",
       // Observe that the provided @context will make the attribute not to match
-      'Link': '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+      Link:
+        '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
-    const response = await http.get(entitiesResource + entityId + '?attrs=P1', headers);
-    assertRetrieved(response,entityNoAttr, JSON_LD);
+    const response = await http.get(
+      entitiesResource + entityId + "?attrs=P1",
+      headers
+    );
+    assertRetrieved(response, entityNoAttr, JSON_LD);
   });
-  
 });

--- a/contextProvision/append_entity_attrs_test.js
+++ b/contextProvision/append_entity_attrs_test.js
@@ -1,121 +1,130 @@
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
-const entitiesResource = testedResource + '/entities/';
+const entitiesResource = testedResource + "/entities/";
 
-describe('Append Entity Attributes. JSON. Default @context', () => {
+describe("Append Entity Attributes. JSON. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     }
   };
 
   const appendedAttributes = {
-    'R1': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789',
-      'R1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T3:A2345'
+    R1: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789",
+      R1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T3:A2345"
       },
-      'R1_P1': {
-        'type': 'Property',
-        'value': false
+      R1_P1: {
+        type: "Property",
+        value: false
       }
     },
-    'location': {
-      'type': 'GeoProperty',
-      'value': {
-        'type': 'Point',
-        'coordinates': [-8.01, 40.01]
+    location: {
+      type: "GeoProperty",
+      value: {
+        type: "Point",
+        coordinates: [-8.01, 40.01]
       }
     }
   };
-  
+
   // The Entity Id has to be properly encoded
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-    
-  it('append Entity Attributes', async function() {
-    const response = await http.post(entitiesResource + entityId + '/attrs/', appendedAttributes);
-        
-    expect(response.response).toHaveProperty('statusCode', 204);
-        
+
+  it("append Entity Attributes", async function() {
+    const response = await http.post(
+      entitiesResource + entityId + "/attrs/",
+      appendedAttributes
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 204);
+
     const checkResponse = await http.get(entitiesResource + entityId);
-        
+
     const finalEntity = Object.assign(entity, appendedAttributes);
     expect(checkResponse.body).toEqual(finalEntity);
   });
-    
-  it('append Entity Attributes. Target entity does not exist', async function() {
-    const response = await http.post(entitiesResource + 'urn:ngsi-ld:doesnotexist'
-                                       + '/attrs/', appendedAttributes);
-        
-    expect(response.response).toHaveProperty('statusCode', 404);
+
+  it("append Entity Attributes. Target entity does not exist", async function() {
+    const response = await http.post(
+      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/",
+      appendedAttributes
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-    
-  it('append Entity Attributes. Empty Payload', async function() {
-    const response = await http.post(entitiesResource + entityId
-                                       + '/attrs/', {});
-        
-    expect(response.response).toHaveProperty('statusCode', 400);
+
+  it("append Entity Attributes. Empty Payload", async function() {
+    const response = await http.post(
+      entitiesResource + entityId + "/attrs/",
+      {}
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
-    
-  it('append Entity Attributes. Attributes are overwritten', async function() {
+
+  it("append Entity Attributes. Attributes are overwritten", async function() {
     const overwrittenAttrs = {
-      'P1': {
-        'type': 'Property',
-        'value': 'Hola'
+      P1: {
+        type: "Property",
+        value: "Hola"
       }
     };
-    const response = await http.post(entitiesResource + entityId
-                                       + '/attrs/', overwrittenAttrs);
-    expect(response.response).toHaveProperty('statusCode', 204);
-        
+    const response = await http.post(
+      entitiesResource + entityId + "/attrs/",
+      overwrittenAttrs
+    );
+    expect(response.response).toHaveProperty("statusCode", 204);
+
     const checkResponse = await http.get(entitiesResource + entityId);
     const finalEntity = Object.assign(entity, overwrittenAttrs);
     expect(checkResponse.body).toEqual(finalEntity);
   });
-    
-  it('append Entity Attributes. Attributes should not be overwritten. Partial success', async function() {
+
+  it("append Entity Attributes. Attributes should not be overwritten. Partial success", async function() {
     const overwrittenAttrs = {
-      'P1': {
-        'type': 'Property',
-        'value': 'Hola'
+      P1: {
+        type: "Property",
+        value: "Hola"
       },
-      'P2': {
-        'type': 'Property',
-        'value': 'Adios'
+      P2: {
+        type: "Property",
+        value: "Adios"
       }
     };
-    const response = await http.post(entitiesResource + entityId
-                                       + '/attrs/?options=noOverwrite',
-    overwrittenAttrs);
-    expect(response.response).toHaveProperty('statusCode', 207);
-        
+    const response = await http.post(
+      entitiesResource + entityId + "/attrs/?options=noOverwrite",
+      overwrittenAttrs
+    );
+    expect(response.response).toHaveProperty("statusCode", 207);
+
     const finalEntity = Object.assign(entity, {});
     finalEntity.P2 = overwrittenAttrs.P2;
-    const checkResponse = await http.get(entitiesResource + entityId);     
+    const checkResponse = await http.get(entitiesResource + entityId);
     expect(checkResponse.body).toEqual(finalEntity);
   });
-  
 });

--- a/contextProvision/append_entity_attrs_test.js
+++ b/contextProvision/append_entity_attrs_test.js
@@ -1,22 +1,22 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Append Entity Attributes. JSON. Default @context", () => {
+describe('Append Entity Attributes. JSON. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00",
+      observedAt: '2018-12-04T12:00:00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     }
@@ -24,21 +24,21 @@ describe("Append Entity Attributes. JSON. Default @context", () => {
 
   const appendedAttributes = {
     R1: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789",
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789',
       R1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T3:A2345"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T3:A2345'
       },
       R1_P1: {
-        type: "Property",
+        type: 'Property',
         value: false
       }
     },
     location: {
-      type: "GeoProperty",
+      type: 'GeoProperty',
       value: {
-        type: "Point",
+        type: 'Point',
         coordinates: [-8.01, 40.01]
       }
     }
@@ -55,13 +55,13 @@ describe("Append Entity Attributes. JSON. Default @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("append Entity Attributes", async function() {
+  it('append Entity Attributes', async function() {
     const response = await http.post(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       appendedAttributes
     );
 
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
 
     const checkResponse = await http.get(entitiesResource + entityId);
 
@@ -69,58 +69,58 @@ describe("Append Entity Attributes. JSON. Default @context", () => {
     expect(checkResponse.body).toEqual(finalEntity);
   });
 
-  it("append Entity Attributes. Target entity does not exist", async function() {
+  it('append Entity Attributes. Target entity does not exist', async function() {
     const response = await http.post(
-      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/",
+      entitiesResource + 'urn:ngsi-ld:doesnotexist/attrs/',
       appendedAttributes
     );
 
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 
-  it("append Entity Attributes. Empty Payload", async function() {
+  it('append Entity Attributes. Empty Payload', async function() {
     const response = await http.post(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       {}
     );
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("append Entity Attributes. Attributes are overwritten", async function() {
+  it('append Entity Attributes. Attributes are overwritten', async function() {
     const overwrittenAttrs = {
       P1: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       }
     };
     const response = await http.post(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       overwrittenAttrs
     );
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
 
     const checkResponse = await http.get(entitiesResource + entityId);
     const finalEntity = Object.assign(entity, overwrittenAttrs);
     expect(checkResponse.body).toEqual(finalEntity);
   });
 
-  it("append Entity Attributes. Attributes should not be overwritten. Partial success", async function() {
+  it('append Entity Attributes. Attributes should not be overwritten. Partial success', async function() {
     const overwrittenAttrs = {
       P1: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       },
       P2: {
-        type: "Property",
-        value: "Adios"
+        type: 'Property',
+        value: 'Adios'
       }
     };
     const response = await http.post(
-      entitiesResource + entityId + "/attrs/?options=noOverwrite",
+      entitiesResource + entityId + '/attrs/?options=noOverwrite',
       overwrittenAttrs
     );
-    expect(response.response).toHaveProperty("statusCode", 207);
+    expect(response.response).toHaveProperty('statusCode', 207);
 
     const finalEntity = Object.assign(entity, {});
     finalEntity.P2 = overwrittenAttrs.P2;

--- a/contextProvision/create_entity_errors_test.js
+++ b/contextProvision/create_entity_errors_test.js
@@ -1,127 +1,127 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Create Entity. Errors. JSON", () => {
-  it("should reject an entity which id is not a URI", async function() {
+describe('Create Entity. Errors. JSON', () => {
+  it('should reject an entity which id is not a URI', async function() {
     const entity = {
-      id: "abcdef",
-      type: "T"
+      id: 'abcdef',
+      type: 'T'
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should reject an entity which node type is not recognized", async function() {
+  it('should reject an entity which node type is not recognized', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T4:9000",
-      type: "T",
+      id: 'urn:ngsi-ld:T4:9000',
+      type: 'T',
       P1: {
-        type: "abcdef",
+        type: 'abcdef',
         value: 34
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should reject an entity with a property value equal to null", async function() {
+  it('should reject an entity with a property value equal to null', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T4:9000",
-      type: "T",
+      id: 'urn:ngsi-ld:T4:9000',
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: null
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should reject an entity with a Relationship with no object", async function() {
+  it('should reject an entity with a Relationship with no object', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T4:9000",
-      type: "T",
+      id: 'urn:ngsi-ld:T4:9000',
+      type: 'T',
       R1: {
-        type: "Relationship",
-        value: "1234"
+        type: 'Relationship',
+        value: '1234'
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should reject an entity with a Property with no value", async function() {
+  it('should reject an entity with a Property with no value', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T4:9000",
-      type: "T",
+      id: 'urn:ngsi-ld:T4:9000',
+      type: 'T',
       P1: {
-        type: "Property",
-        object: "1234"
+        type: 'Property',
+        object: '1234'
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should reject an entity with a Relationship object equal to null", async function() {
+  it('should reject an entity with a Relationship object equal to null', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T4:9000",
-      type: "T",
+      id: 'urn:ngsi-ld:T4:9000',
+      type: 'T',
       R1: {
-        type: "Relationship",
+        type: 'Relationship',
         object: null
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should report an error if @context is provided in a JSON payload", async function() {
+  it('should report an error if @context is provided in a JSON payload', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
-      "@context": "http://example.org/ldContext/"
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
+      '@context': 'http://example.org/ldContext/'
     };
 
     const response = await http.post(entitiesResource, entity);
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should report an error if no @context is provided in a JSON-LD payload", async function() {
+  it('should report an error if no @context is provided in a JSON-LD payload', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T"
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T'
     };
 
     const response = await http.post(entitiesResource, entity, {
-      "Content-Type": "application/ld+json"
+      'Content-Type': 'application/ld+json'
     });
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("should report an error if a JSON-LD header is provided with a JSON-LD payload", async function() {
+  it('should report an error if a JSON-LD header is provided with a JSON-LD payload', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T"
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T'
     };
 
     const response = await http.post(entitiesResource, entity, {
-      "Content-Type": "application/ld+json",
+      'Content-Type': 'application/ld+json',
       Link:
         '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     });
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
   // TODO: Add here more tests (null values, etc.)

--- a/contextProvision/create_entity_errors_test.js
+++ b/contextProvision/create_entity_errors_test.js
@@ -1,128 +1,127 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('Create Entity. Errors. JSON', () => {
-  it('should reject an entity which id is not a URI', async function() {
+describe("Create Entity. Errors. JSON", () => {
+  it("should reject an entity which id is not a URI", async function() {
     const entity = {
-      'id': 'abcdef',
-      'type': 'T'
+      id: "abcdef",
+      type: "T"
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
-  it('should reject an entity which node type is not recognized', async function() {
+  it("should reject an entity which node type is not recognized", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T4:9000',
-      'type': 'T',
-      'P1': {
-        'type': 'abcdef',
-        'value': 34
+      id: "urn:ngsi-ld:T4:9000",
+      type: "T",
+      P1: {
+        type: "abcdef",
+        value: 34
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
-  it('should reject an entity with a property value equal to null', async function() {
+  it("should reject an entity with a property value equal to null", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T4:9000',
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': null
+      id: "urn:ngsi-ld:T4:9000",
+      type: "T",
+      P1: {
+        type: "Property",
+        value: null
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
-  it('should reject an entity with a Relationship with no object', async function() {
+  it("should reject an entity with a Relationship with no object", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T4:9000',
-      'type': 'T',
-      'R1': {
-        'type': 'Relationship',
-        'value': '1234'
+      id: "urn:ngsi-ld:T4:9000",
+      type: "T",
+      R1: {
+        type: "Relationship",
+        value: "1234"
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
-  it('should reject an entity with a Property with no value', async function() {
+  it("should reject an entity with a Property with no value", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T4:9000',
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'object': '1234'
+      id: "urn:ngsi-ld:T4:9000",
+      type: "T",
+      P1: {
+        type: "Property",
+        object: "1234"
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
-  it('should reject an entity with a Relationship object equal to null', async function() {
+  it("should reject an entity with a Relationship object equal to null", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T4:9000',
-      'type': 'T',
-      'R1': {
-        'type': 'Relationship',
-        'object': null
+      id: "urn:ngsi-ld:T4:9000",
+      type: "T",
+      R1: {
+        type: "Relationship",
+        object: null
       }
     };
 
     const response = await http.post(entitiesResource, entity);
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
-  
-  it('should report an error if @context is provided in a JSON payload', async function() {
+
+  it("should report an error if @context is provided in a JSON payload", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      '@context': 'http://example.org/ldContext/'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      "@context": "http://example.org/ldContext/"
     };
 
     const response = await http.post(entitiesResource, entity);
 
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
-  
-  it('should report an error if no @context is provided in a JSON-LD payload', async function() {
+
+  it("should report an error if no @context is provided in a JSON-LD payload", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T"
     };
 
     const response = await http.post(entitiesResource, entity, {
-      'Content-Type': 'application/ld+json'
+      "Content-Type": "application/ld+json"
     });
 
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
-  
-  it('should report an error if a JSON-LD header is provided with a JSON-LD payload', async function() {
+
+  it("should report an error if a JSON-LD header is provided with a JSON-LD payload", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T"
     };
 
     const response = await http.post(entitiesResource, entity, {
-      'Content-Type': 'application/ld+json',
-      'Link': '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+      "Content-Type": "application/ld+json",
+      Link:
+        '<https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     });
 
-    expect(response.response).toHaveProperty('statusCode', 400);
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 
   // TODO: Add here more tests (null values, etc.)

--- a/contextProvision/create_entity_test.js
+++ b/contextProvision/create_entity_test.js
@@ -1,29 +1,27 @@
+const testedResource = require("../common.js").testedResource;
+const assertCreated = require("../common.js").assertCreated;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const assertCreated = require('../common.js').assertCreated;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('Create Entity. JSON', () => {
-  it('should create an empty entity', async function() {
+describe("Create Entity. JSON", () => {
+  it("should create an empty entity", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T"
     };
 
     const response = await http.post(entitiesResource, entity);
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. One Property', async function() {
+  it("should create an entity. One Property", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 'Hola'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: "Hola"
       }
     };
 
@@ -31,15 +29,15 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. One GeoProperty', async function() {
+  it("should create an entity. One GeoProperty", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'location': {
-        'type': 'GeoProperty',
-        'value': {
-          'type': 'Point',
-          'coordinates': [-8, 40]
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      location: {
+        type: "GeoProperty",
+        value: {
+          type: "Point",
+          coordinates: [-8, 40]
         }
       }
     };
@@ -48,15 +46,15 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. One Property. DateTime', async function() {
+  it("should create an entity. One Property. DateTime", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': {
-          '@type': 'DateTime',
-          '@value': '2018-12-04T12:00:00'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: {
+          "@type": "DateTime",
+          "@value": "2018-12-04T12:00:00"
         }
       }
     };
@@ -65,17 +63,17 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Property. Relationship', async function() {
+  it("should create an entity. Property. Relationship", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 'Hola'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: "Hola"
       },
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       }
     };
 
@@ -83,14 +81,14 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Property. observedAt', async function() {
+  it("should create an entity. Property. observedAt", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 12,
-        'observedAt': '2018-12-04T12:00:00'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: 12,
+        observedAt: "2018-12-04T12:00:00"
       }
     };
 
@@ -98,14 +96,14 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Property. unitCode', async function() {
+  it("should create an entity. Property. unitCode", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 12.45,
-        'unitCode': 'm'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: 12.45,
+        unitCode: "m"
       }
     };
 
@@ -113,14 +111,14 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Relationship. observedAt', async function() {
+  it("should create an entity. Relationship. observedAt", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789',
-        'observedAt': '2018-12-04T12:00:00'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789",
+        observedAt: "2018-12-04T12:00:00"
       }
     };
 
@@ -128,17 +126,17 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Property. Property', async function() {
+  it("should create an entity. Property. Property", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 12,
-        'observedAt': '2018-12-04T12:00:00',
-        'P1_P1': {
-          'type': 'Property',
-          'value': 0.89
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: 12,
+        observedAt: "2018-12-04T12:00:00",
+        P1_P1: {
+          type: "Property",
+          value: 0.89
         }
       }
     };
@@ -147,17 +145,16 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-
-  it('should create an entity. Relationship. Property', async function() {
+  it("should create an entity. Relationship. Property", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789',
-        'R1_P1': {
-          'type': 'Property',
-          'value': 'V'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789",
+        R1_P1: {
+          type: "Property",
+          value: "V"
         }
       }
     };
@@ -166,17 +163,17 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Property. Relationship', async function() {
+  it("should create an entity. Property. Relationship", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P1': {
-        'type': 'Property',
-        'value': 12,
-        'observedAt': '2018-12-04T12:00:00',
-        'P1_R1': {
-          'type': 'Relationship',
-          'object': 'urn:ngsi-ld:T2:6789'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P1: {
+        type: "Property",
+        value: 12,
+        observedAt: "2018-12-04T12:00:00",
+        P1_R1: {
+          type: "Relationship",
+          object: "urn:ngsi-ld:T2:6789"
         }
       }
     };
@@ -185,16 +182,16 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity. Relationship. Relationship', async function() {
+  it("should create an entity. Relationship. Relationship", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789',
-        'R1_R1': {
-          'type': 'Relationship',
-          'object': 'urn:ngsi-ld:T3:A2345'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789",
+        R1_R1: {
+          type: "Relationship",
+          object: "urn:ngsi-ld:T3:A2345"
         }
       }
     };
@@ -203,16 +200,15 @@ describe('Create Entity. JSON', () => {
     assertCreated(response.response, entity.id);
   });
 
-  it('should report an error if Entity already exists', async function() {
+  it("should report an error if Entity already exists", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T"
     };
 
     await http.post(entitiesResource, entity);
     const response2 = await http.post(entitiesResource, entity);
 
-    expect(response2.response).toHaveProperty('statusCode', 409);
+    expect(response2.response).toHaveProperty("statusCode", 409);
   });
-  
 });

--- a/contextProvision/create_entity_test.js
+++ b/contextProvision/create_entity_test.js
@@ -1,27 +1,27 @@
-const testedResource = require("../common.js").testedResource;
-const assertCreated = require("../common.js").assertCreated;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const assertCreated = require('../common.js').assertCreated;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Create Entity. JSON", () => {
-  it("should create an empty entity", async function() {
+describe('Create Entity. JSON', () => {
+  it('should create an empty entity', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T"
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T'
     };
 
     const response = await http.post(entitiesResource, entity);
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. One Property", async function() {
+  it('should create an entity. One Property', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       }
     };
 
@@ -29,14 +29,14 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. One GeoProperty", async function() {
+  it('should create an entity. One GeoProperty', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       location: {
-        type: "GeoProperty",
+        type: 'GeoProperty',
         value: {
-          type: "Point",
+          type: 'Point',
           coordinates: [-8, 40]
         }
       }
@@ -46,15 +46,15 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. One Property. DateTime", async function() {
+  it('should create an entity. One Property. DateTime', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: {
-          "@type": "DateTime",
-          "@value": "2018-12-04T12:00:00"
+          '@type': 'DateTime',
+          '@value': '2018-12-04T12:00:00'
         }
       }
     };
@@ -63,17 +63,17 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Property. Relationship", async function() {
+  it('should create an entity. Property. Relationship', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       },
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       }
     };
 
@@ -81,14 +81,14 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Property. observedAt", async function() {
+  it('should create an entity. Property. observedAt', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: 12,
-        observedAt: "2018-12-04T12:00:00"
+        observedAt: '2018-12-04T12:00:00'
       }
     };
 
@@ -96,14 +96,14 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Property. unitCode", async function() {
+  it('should create an entity. Property. unitCode', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: 12.45,
-        unitCode: "m"
+        unitCode: 'm'
       }
     };
 
@@ -111,14 +111,14 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Relationship. observedAt", async function() {
+  it('should create an entity. Relationship. observedAt', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789",
-        observedAt: "2018-12-04T12:00:00"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789',
+        observedAt: '2018-12-04T12:00:00'
       }
     };
 
@@ -126,16 +126,16 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Property. Property", async function() {
+  it('should create an entity. Property. Property', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: 12,
-        observedAt: "2018-12-04T12:00:00",
+        observedAt: '2018-12-04T12:00:00',
         P1_P1: {
-          type: "Property",
+          type: 'Property',
           value: 0.89
         }
       }
@@ -145,16 +145,16 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Relationship. Property", async function() {
+  it('should create an entity. Relationship. Property', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789",
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789',
         R1_P1: {
-          type: "Property",
-          value: "V"
+          type: 'Property',
+          value: 'V'
         }
       }
     };
@@ -163,17 +163,17 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Property. Relationship", async function() {
+  it('should create an entity. Property. Relationship', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P1: {
-        type: "Property",
+        type: 'Property',
         value: 12,
-        observedAt: "2018-12-04T12:00:00",
+        observedAt: '2018-12-04T12:00:00',
         P1_R1: {
-          type: "Relationship",
-          object: "urn:ngsi-ld:T2:6789"
+          type: 'Relationship',
+          object: 'urn:ngsi-ld:T2:6789'
         }
       }
     };
@@ -182,16 +182,16 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity. Relationship. Relationship", async function() {
+  it('should create an entity. Relationship. Relationship', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789",
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789',
         R1_R1: {
-          type: "Relationship",
-          object: "urn:ngsi-ld:T3:A2345"
+          type: 'Relationship',
+          object: 'urn:ngsi-ld:T3:A2345'
         }
       }
     };
@@ -200,15 +200,15 @@ describe("Create Entity. JSON", () => {
     assertCreated(response.response, entity.id);
   });
 
-  it("should report an error if Entity already exists", async function() {
+  it('should report an error if Entity already exists', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T"
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T'
     };
 
     await http.post(entitiesResource, entity);
     const response2 = await http.post(entitiesResource, entity);
 
-    expect(response2.response).toHaveProperty("statusCode", 409);
+    expect(response2.response).toHaveProperty('statusCode', 409);
   });
 });

--- a/contextProvision/create_entity_with_ldcontext_test.js
+++ b/contextProvision/create_entity_with_ldcontext_test.js
@@ -1,85 +1,85 @@
-const testedResource = require("../common.js").testedResource;
-const assertCreated = require("../common.js").assertCreated;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const assertCreated = require('../common.js').assertCreated;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
 const JSON_LD_HEADERS = {
-  "Content-Type": "application/ld+json"
+  'Content-Type': 'application/ld+json'
 };
 
-describe("Create Entity. JSON-LD @context", () => {
-  it("should create an entity with JSON-LD @context as single URI", async function() {
+describe('Create Entity. JSON-LD @context', () => {
+  it('should create an entity with JSON-LD @context as single URI', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       P2: {
-        type: "GeoProperty",
+        type: 'GeoProperty',
         value: {
-          type: "Point",
+          type: 'Point',
           coordinates: [-8, 40]
         }
       },
       P3: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       },
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
-      "@context":
-        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+      '@context':
+        'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
     };
 
     const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity with JSON-LD @context as single URI. DateTime Property inline", async function() {
+  it('should create an entity with JSON-LD @context as single URI. DateTime Property inline', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       DateProp: {
-        type: "Property",
+        type: 'Property',
         value: {
-          "@type": "DateTime",
-          "@value": "2018-12-04T12:00:00"
+          '@type': 'DateTime',
+          '@value': '2018-12-04T12:00:00'
         }
       },
       P2: {
-        type: "GeoProperty",
+        type: 'GeoProperty',
         value: {
-          type: "Point",
+          type: 'Point',
           coordinates: [-8, 40]
         }
       },
       P3: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       },
       R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
-      "@context":
-        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+      '@context':
+        'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
     };
 
     const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
     assertCreated(response.response, entity.id);
   });
 
-  it("should create an entity with JSON-LD @context as a vector of URIs", async function() {
+  it('should create an entity with JSON-LD @context as a vector of URIs', async function() {
     const entity = {
-      id: "urn:ngsi-ld:T:" + new Date().getTime(),
-      type: "T",
+      id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+      type: 'T',
       DateProp: {
-        type: "Property",
-        value: "2018-12-04T12:00:00"
+        type: 'Property',
+        value: '2018-12-04T12:00:00'
       },
-      "@context": [
-        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+      '@context': [
+        'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
       ]
     };
 

--- a/contextProvision/create_entity_with_ldcontext_test.js
+++ b/contextProvision/create_entity_with_ldcontext_test.js
@@ -1,89 +1,89 @@
+const testedResource = require("../common.js").testedResource;
+const assertCreated = require("../common.js").assertCreated;
+const http = require("../http.js");
 
-
-const testedResource = require('../common.js').testedResource;
-const assertCreated = require('../common.js').assertCreated;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
+const entitiesResource = testedResource + "/entities/";
 
 const JSON_LD_HEADERS = {
-  'Content-Type': 'application/ld+json'
+  "Content-Type": "application/ld+json"
 };
 
-describe('Create Entity. JSON-LD @context', () => {
-  
-  it('should create an entity with JSON-LD @context as single URI', async function() {
+describe("Create Entity. JSON-LD @context", () => {
+  it("should create an entity with JSON-LD @context as single URI", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'P2': {
-        'type': 'GeoProperty',
-        'value': {
-          'type': 'Point',
-          'coordinates': [-8, 40]
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      P2: {
+        type: "GeoProperty",
+        value: {
+          type: "Point",
+          coordinates: [-8, 40]
         }
       },
-      'P3': {
-        'type': 'Property',
-        'value': 'Hola'
+      P3: {
+        type: "Property",
+        value: "Hola"
       },
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      '@context': 'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
-    };
-
-    const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
-    assertCreated(response.response, entity.id);
-  });
-  
-  it('should create an entity with JSON-LD @context as single URI. DateTime Property inline', async function() {
-    const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'DateProp': {
-        'type':  'Property',
-        'value': {
-          '@type': 'DateTime',
-          '@value': '2018-12-04T12:00:00'
-        }
-      },
-      'P2': {
-        'type': 'GeoProperty',
-        'value': {
-          'type': 'Point',
-          'coordinates': [-8, 40]
-        }
-      },
-      'P3': {
-        'type': 'Property',
-        'value': 'Hola'
-      },
-      'R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
-      },
-      '@context': 'https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld'
+      "@context":
+        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
     };
 
     const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
     assertCreated(response.response, entity.id);
   });
 
-  it('should create an entity with JSON-LD @context as a vector of URIs', async function() {
+  it("should create an entity with JSON-LD @context as single URI. DateTime Property inline", async function() {
     const entity = {
-      'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-      'type': 'T',
-      'DateProp': {
-        'type': 'Property',
-        'value': '2018-12-04T12:00:00'
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      DateProp: {
+        type: "Property",
+        value: {
+          "@type": "DateTime",
+          "@value": "2018-12-04T12:00:00"
+        }
       },
-      '@context': ['https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld']
+      P2: {
+        type: "GeoProperty",
+        value: {
+          type: "Point",
+          coordinates: [-8, 40]
+        }
+      },
+      P3: {
+        type: "Property",
+        value: "Hola"
+      },
+      R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
+      },
+      "@context":
+        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
     };
 
     const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
     assertCreated(response.response, entity.id);
   });
 
+  it("should create an entity with JSON-LD @context as a vector of URIs", async function() {
+    const entity = {
+      id: "urn:ngsi-ld:T:" + new Date().getTime(),
+      type: "T",
+      DateProp: {
+        type: "Property",
+        value: "2018-12-04T12:00:00"
+      },
+      "@context": [
+        "https://fiware.github.io/NGSI-LD_Tests/ldContext/testFullContext.jsonld"
+      ]
+    };
+
+    const response = await http.post(entitiesResource, entity, JSON_LD_HEADERS);
+    assertCreated(response.response, entity.id);
+  });
 });

--- a/contextProvision/delete_entity_attr_test.js
+++ b/contextProvision/delete_entity_attr_test.js
@@ -1,15 +1,15 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Delete Entity Attribute. Default @context", () => {
+describe('Delete Entity Attribute. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
-      value: "abcde"
+      type: 'Property',
+      value: 'abcde'
     }
   };
 
@@ -19,17 +19,17 @@ describe("Delete Entity Attribute. Default @context", () => {
     return http.post(entitiesResource, entity);
   });
 
-  it("should delete the entity attribute", async function() {
+  it('should delete the entity attribute', async function() {
     const response = await http.delete(
-      entitiesResource + entityId + "/attrs/P1"
+      entitiesResource + entityId + '/attrs/P1'
     );
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
   });
 
-  it("should return 404 if attribute does not exist", async function() {
+  it('should return 404 if attribute does not exist', async function() {
     const response = await http.delete(
-      entitiesResource + entityId + "/attrs/P1"
+      entitiesResource + entityId + '/attrs/P1'
     );
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 });

--- a/contextProvision/delete_entity_attr_test.js
+++ b/contextProvision/delete_entity_attr_test.js
@@ -1,34 +1,35 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('Delete Entity Attribute. Default @context', () => {
+describe("Delete Entity Attribute. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 'abcde'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: "abcde"
     }
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
-  it('should delete the entity attribute', async function() {
-    const response = await http.delete(entitiesResource + entityId + '/attrs/P1');
-    expect(response.response).toHaveProperty('statusCode', 204);       
+
+  it("should delete the entity attribute", async function() {
+    const response = await http.delete(
+      entitiesResource + entityId + "/attrs/P1"
+    );
+    expect(response.response).toHaveProperty("statusCode", 204);
   });
-    
-  it('should return 404 if attribute does not exist', async function() {
-    const response = await http.delete(entitiesResource + entityId + '/attrs/P1');
-    expect(response.response).toHaveProperty('statusCode', 404);    
+
+  it("should return 404 if attribute does not exist", async function() {
+    const response = await http.delete(
+      entitiesResource + entityId + "/attrs/P1"
+    );
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-  
 });

--- a/contextProvision/delete_entity_test.js
+++ b/contextProvision/delete_entity_test.js
@@ -1,12 +1,12 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Delete Entity.", () => {
+describe('Delete Entity.', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T"
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T'
   };
 
   const entityId = encodeURIComponent(entity.id);
@@ -15,13 +15,13 @@ describe("Delete Entity.", () => {
     return http.post(entitiesResource, entity);
   });
 
-  it("should delete the entity", async function() {
+  it('should delete the entity', async function() {
     const response = await http.delete(entitiesResource + entityId);
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
   });
 
-  it("should return 404 if entity does not exist", async function() {
+  it('should return 404 if entity does not exist', async function() {
     const response = await http.delete(entitiesResource + entityId);
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 });

--- a/contextProvision/delete_entity_test.js
+++ b/contextProvision/delete_entity_test.js
@@ -1,29 +1,27 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('Delete Entity.', () => {
+describe("Delete Entity.", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T"
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
-  it('should delete the entity', async function() {
+
+  it("should delete the entity", async function() {
     const response = await http.delete(entitiesResource + entityId);
-    expect(response.response).toHaveProperty('statusCode', 204);       
+    expect(response.response).toHaveProperty("statusCode", 204);
   });
-    
-  it('should return 404 if entity does not exist', async function() {
+
+  it("should return 404 if entity does not exist", async function() {
     const response = await http.delete(entitiesResource + entityId);
-    expect(response.response).toHaveProperty('statusCode', 404);    
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
 });

--- a/contextProvision/partial_attr_update_test.js
+++ b/contextProvision/partial_attr_update_test.js
@@ -1,22 +1,22 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Partial Entity Attribute Update. JSON. Default @context", () => {
+describe('Partial Entity Attribute Update. JSON. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00",
+      observedAt: '2018-12-04T12:00:00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     }
@@ -36,12 +36,12 @@ describe("Partial Entity Attribute Update. JSON. Default @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("Partial Attribute Update.", async function() {
+  it('Partial Attribute Update.', async function() {
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/P1",
+      entitiesResource + entityId + '/attrs/P1',
       partialUpdate
     );
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
 
     const checkResponse = await http.get(entitiesResource + entityId);
 
@@ -50,30 +50,30 @@ describe("Partial Entity Attribute Update. JSON. Default @context", () => {
     expect(checkResponse.body).toEqual(finalEntity);
   });
 
-  it("Partial Attribute Update. Target entity does not exist", async function() {
+  it('Partial Attribute Update. Target entity does not exist', async function() {
     const response = await http.patch(
-      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/P1",
+      entitiesResource + 'urn:ngsi-ld:doesnotexist/attrs/P1',
       partialUpdate
     );
 
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 
-  it("Partial Attribute Update. Target Attribute does not exist", async function() {
+  it('Partial Attribute Update. Target Attribute does not exist', async function() {
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/NonExistentAttribute",
+      entitiesResource + entityId + '/attrs/NonExistentAttribute',
       partialUpdate
     );
 
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 
-  it("Partial Attribute Update. Empty Payload", async function() {
+  it('Partial Attribute Update. Empty Payload', async function() {
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/P1",
+      entitiesResource + entityId + '/attrs/P1',
       {}
     );
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 });

--- a/contextProvision/partial_attr_update_test.js
+++ b/contextProvision/partial_attr_update_test.js
@@ -1,72 +1,79 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('Partial Entity Attribute Update. JSON. Default @context', () => {
+describe("Partial Entity Attribute Update. JSON. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     }
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   const partialUpdate = {
-    'value': 55
+    value: 55
   };
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-    
-  it('Partial Attribute Update.', async function() {
-    const response = await http.patch(entitiesResource + entityId + '/attrs/P1', partialUpdate);
-    expect(response.response).toHaveProperty('statusCode', 204);
-        
+
+  it("Partial Attribute Update.", async function() {
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/P1",
+      partialUpdate
+    );
+    expect(response.response).toHaveProperty("statusCode", 204);
+
     const checkResponse = await http.get(entitiesResource + entityId);
-        
+
     const finalEntity = Object.assign(entity, {});
     finalEntity.P1.value = partialUpdate.value;
     expect(checkResponse.body).toEqual(finalEntity);
   });
-    
-  it('Partial Attribute Update. Target entity does not exist', async function() {
-    const response = await http.patch(entitiesResource + 'urn:ngsi-ld:doesnotexist'
-                                       + '/attrs/P1', partialUpdate);
-        
-    expect(response.response).toHaveProperty('statusCode', 404);
+
+  it("Partial Attribute Update. Target entity does not exist", async function() {
+    const response = await http.patch(
+      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/P1",
+      partialUpdate
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-    
-  it('Partial Attribute Update. Target Attribute does not exist', async function() {
-    const response = await http.patch(entitiesResource + entityId
-                                       + '/attrs/NonExistentAttribute', partialUpdate);
-        
-    expect(response.response).toHaveProperty('statusCode', 404);
+
+  it("Partial Attribute Update. Target Attribute does not exist", async function() {
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/NonExistentAttribute",
+      partialUpdate
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-    
-  it('Partial Attribute Update. Empty Payload', async function() {
-    const response = await http.patch(entitiesResource + entityId
-                                       + '/attrs/P1', {});
-        
-    expect(response.response).toHaveProperty('statusCode', 400);
+
+  it("Partial Attribute Update. Empty Payload", async function() {
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/P1",
+      {}
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
 });

--- a/contextProvision/protocol_errors_test.js
+++ b/contextProvision/protocol_errors_test.js
@@ -1,19 +1,19 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("NGSI-LD Protocol. Errors", () => {
-  it("should reject content which is not JSON nor JSON-LD", async function() {
+describe('NGSI-LD Protocol. Errors', () => {
+  it('should reject content which is not JSON nor JSON-LD', async function() {
     const data = {
-      id: "abcdef",
-      type: "T"
+      id: 'abcdef',
+      type: 'T'
     };
 
     const response = await http.post(entitiesResource, data, {
-      "Content-Type": "image/gif"
+      'Content-Type': 'image/gif'
     });
-    expect(response.response).toHaveProperty("statusCode", 415);
+    expect(response.response).toHaveProperty('statusCode', 415);
   });
 
   // TODO: Add here more tests

--- a/contextProvision/protocol_errors_test.js
+++ b/contextProvision/protocol_errors_test.js
@@ -1,19 +1,19 @@
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
+const entitiesResource = testedResource + "/entities/";
 
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
-
-const entitiesResource = testedResource + '/entities/';
-
-describe('NGSI-LD Protocol. Errors', () => {
-  it('should reject content which is not JSON nor JSON-LD', async function() {
+describe("NGSI-LD Protocol. Errors", () => {
+  it("should reject content which is not JSON nor JSON-LD", async function() {
     const data = {
-      'id': 'abcdef',
-      'type': 'T'
+      id: "abcdef",
+      type: "T"
     };
 
-    const response = await http.post(entitiesResource, data, { 'Content-Type': 'image/gif' });
-    expect(response.response).toHaveProperty('statusCode', 415);
+    const response = await http.post(entitiesResource, data, {
+      "Content-Type": "image/gif"
+    });
+    expect(response.response).toHaveProperty("statusCode", 415);
   });
 
   // TODO: Add here more tests

--- a/contextProvision/update_entity_attrs_test.js
+++ b/contextProvision/update_entity_attrs_test.js
@@ -1,22 +1,22 @@
-const testedResource = require("../common.js").testedResource;
-const http = require("../http.js");
+const testedResource = require('../common.js').testedResource;
+const http = require('../http.js');
 
-const entitiesResource = testedResource + "/entities/";
+const entitiesResource = testedResource + '/entities/';
 
-describe("Update Entity Attributes. JSON. Default @context", () => {
+describe('Update Entity Attributes. JSON. Default @context', () => {
   const entity = {
-    id: "urn:ngsi-ld:T:" + new Date().getTime(),
-    type: "T",
+    id: 'urn:ngsi-ld:T:' + new Date().getTime(),
+    type: 'T',
     P1: {
-      type: "Property",
+      type: 'Property',
       value: 12,
-      observedAt: "2018-12-04T12:00:00.00",
+      observedAt: '2018-12-04T12:00:00.00',
       P1_R1: {
-        type: "Relationship",
-        object: "urn:ngsi-ld:T2:6789"
+        type: 'Relationship',
+        object: 'urn:ngsi-ld:T2:6789'
       },
       P1_P1: {
-        type: "Property",
+        type: 'Property',
         value: 0.79
       }
     }
@@ -24,13 +24,13 @@ describe("Update Entity Attributes. JSON. Default @context", () => {
 
   const updatedAttributes = {
     P1: {
-      type: "Relationship",
-      object: "urn:ngsi-ld:T2:6789"
+      type: 'Relationship',
+      object: 'urn:ngsi-ld:T2:6789'
     },
     location: {
-      type: "GeoProperty",
+      type: 'GeoProperty',
       value: {
-        type: "Point",
+        type: 'Point',
         coordinates: [-8.01, 40.01]
       }
     }
@@ -46,12 +46,12 @@ describe("Update Entity Attributes. JSON. Default @context", () => {
     return http.delete(entitiesResource + entityId);
   });
 
-  it("Update Entity Attributes. Partial success", async function() {
+  it('Update Entity Attributes. Partial success', async function() {
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       updatedAttributes
     );
-    expect(response.response).toHaveProperty("statusCode", 207);
+    expect(response.response).toHaveProperty('statusCode', 207);
 
     const checkResponse = await http.get(entitiesResource + entityId);
 
@@ -60,36 +60,36 @@ describe("Update Entity Attributes. JSON. Default @context", () => {
     expect(checkResponse.body).toEqual(finalEntity);
   });
 
-  it("Update Entity Attributes. Target entity does not exist", async function() {
+  it('Update Entity Attributes. Target entity does not exist', async function() {
     const response = await http.patch(
-      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/",
+      entitiesResource + 'urn:ngsi-ld:doesnotexist/attrs/',
       updatedAttributes
     );
 
-    expect(response.response).toHaveProperty("statusCode", 404);
+    expect(response.response).toHaveProperty('statusCode', 404);
   });
 
-  it("Update Entity Attributes. Empty Payload", async function() {
+  it('Update Entity Attributes. Empty Payload', async function() {
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       {}
     );
 
-    expect(response.response).toHaveProperty("statusCode", 400);
+    expect(response.response).toHaveProperty('statusCode', 400);
   });
 
-  it("Update Entity Attributes. All Attributes are overwritten", async function() {
+  it('Update Entity Attributes. All Attributes are overwritten', async function() {
     const overwrittenAttrs = {
       P1: {
-        type: "Property",
-        value: "Hola"
+        type: 'Property',
+        value: 'Hola'
       }
     };
     const response = await http.patch(
-      entitiesResource + entityId + "/attrs/",
+      entitiesResource + entityId + '/attrs/',
       overwrittenAttrs
     );
-    expect(response.response).toHaveProperty("statusCode", 204);
+    expect(response.response).toHaveProperty('statusCode', 204);
 
     const checkResponse = await http.get(entitiesResource + entityId);
     const finalEntity = Object.assign(entity, overwrittenAttrs);

--- a/contextProvision/update_entity_attrs_test.js
+++ b/contextProvision/update_entity_attrs_test.js
@@ -1,87 +1,96 @@
-const testedResource = require('../common.js').testedResource;
-const http = require('../http.js');
+const testedResource = require("../common.js").testedResource;
+const http = require("../http.js");
 
-const entitiesResource = testedResource + '/entities/';
+const entitiesResource = testedResource + "/entities/";
 
-describe('Update Entity Attributes. JSON. Default @context', () => {
+describe("Update Entity Attributes. JSON. Default @context", () => {
   const entity = {
-    'id': 'urn:ngsi-ld:T:' + new Date().getTime(),
-    'type': 'T',
-    'P1': {
-      'type': 'Property',
-      'value': 12,
-      'observedAt': '2018-12-04T12:00:00.00',
-      'P1_R1': {
-        'type': 'Relationship',
-        'object': 'urn:ngsi-ld:T2:6789'
+    id: "urn:ngsi-ld:T:" + new Date().getTime(),
+    type: "T",
+    P1: {
+      type: "Property",
+      value: 12,
+      observedAt: "2018-12-04T12:00:00.00",
+      P1_R1: {
+        type: "Relationship",
+        object: "urn:ngsi-ld:T2:6789"
       },
-      'P1_P1': {
-        'type': 'Property',
-        'value': 0.79
+      P1_P1: {
+        type: "Property",
+        value: 0.79
       }
     }
   };
 
   const updatedAttributes = {
-    'P1': {
-      'type': 'Relationship',
-      'object': 'urn:ngsi-ld:T2:6789'
+    P1: {
+      type: "Relationship",
+      object: "urn:ngsi-ld:T2:6789"
     },
-    'location': {
-      'type': 'GeoProperty',
-      'value': {
-        'type': 'Point',
-        'coordinates': [-8.01, 40.01]
+    location: {
+      type: "GeoProperty",
+      value: {
+        type: "Point",
+        coordinates: [-8.01, 40.01]
       }
     }
   };
-  
+
   const entityId = encodeURIComponent(entity.id);
 
   beforeAll(() => {
     return http.post(entitiesResource, entity);
   });
-    
+
   afterAll(() => {
     return http.delete(entitiesResource + entityId);
   });
-    
-  it('Update Entity Attributes. Partial success', async function() {
-    const response = await http.patch(entitiesResource + entityId + '/attrs/', updatedAttributes);
-    expect(response.response).toHaveProperty('statusCode', 207);
-        
+
+  it("Update Entity Attributes. Partial success", async function() {
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/",
+      updatedAttributes
+    );
+    expect(response.response).toHaveProperty("statusCode", 207);
+
     const checkResponse = await http.get(entitiesResource + entityId);
-        
+
     const finalEntity = Object.assign(entity, {});
     finalEntity.P1 = updatedAttributes.P1;
     expect(checkResponse.body).toEqual(finalEntity);
   });
-    
-  it('Update Entity Attributes. Target entity does not exist', async function() {
-    const response = await http.patch(entitiesResource + 'urn:ngsi-ld:doesnotexist'
-                                       + '/attrs/', updatedAttributes);
-        
-    expect(response.response).toHaveProperty('statusCode', 404);
+
+  it("Update Entity Attributes. Target entity does not exist", async function() {
+    const response = await http.patch(
+      entitiesResource + "urn:ngsi-ld:doesnotexist/attrs/",
+      updatedAttributes
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 404);
   });
-    
-  it('Update Entity Attributes. Empty Payload', async function() {
-    const response = await http.patch(entitiesResource + entityId
-                                       + '/attrs/', {});
-        
-    expect(response.response).toHaveProperty('statusCode', 400);
+
+  it("Update Entity Attributes. Empty Payload", async function() {
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/",
+      {}
+    );
+
+    expect(response.response).toHaveProperty("statusCode", 400);
   });
-    
-  it('Update Entity Attributes. All Attributes are overwritten', async function() {
+
+  it("Update Entity Attributes. All Attributes are overwritten", async function() {
     const overwrittenAttrs = {
-      'P1': {
-        'type': 'Property',
-        'value': 'Hola'
+      P1: {
+        type: "Property",
+        value: "Hola"
       }
     };
-    const response = await http.patch(entitiesResource + entityId
-                                       + '/attrs/', overwrittenAttrs);
-    expect(response.response).toHaveProperty('statusCode', 204);
-        
+    const response = await http.patch(
+      entitiesResource + entityId + "/attrs/",
+      overwrittenAttrs
+    );
+    expect(response.response).toHaveProperty("statusCode", 204);
+
     const checkResponse = await http.get(entitiesResource + entityId);
     const finalEntity = Object.assign(entity, overwrittenAttrs);
     expect(checkResponse.body).toEqual(finalEntity);

--- a/http.js
+++ b/http.js
@@ -6,18 +6,16 @@
  *
  */
 
-
-
-const request = require('request');
+const request = require("request");
 
 function post(resource, data, headers) {
   headers = headers || {
-    'Content-Type': 'application/json'
+    "Content-Type": "application/json"
   };
-  
+
   return new Promise(function(resolve, reject) {
     const options = {
-      method: 'POST',
+      method: "POST",
       uri: resource,
       body: data,
       headers,
@@ -26,10 +24,12 @@ function post(resource, data, headers) {
     };
 
     request(options, function(error, response, body) {
-      return error ? reject(error) : resolve({
-        response,
-        body
-      });
+      return error
+        ? reject(error)
+        : resolve({
+            response,
+            body
+          });
     });
   });
 }
@@ -37,17 +37,19 @@ function post(resource, data, headers) {
 function get(resource, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: 'GET',
+      method: "GET",
       uri: resource,
       headers,
       json: true
     };
 
     request(options, function(error, response, body) {
-      return error ? reject(error) : resolve({
-        response,
-        body
-      });
+      return error
+        ? reject(error)
+        : resolve({
+            response,
+            body
+          });
     });
   });
 }
@@ -55,17 +57,19 @@ function get(resource, headers) {
 function del(resource, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: 'DELETE',
+      method: "DELETE",
       uri: resource,
       headers,
       json: true
     };
 
     request(options, function(error, response, body) {
-      return error ? reject(error) : resolve({
-        response,
-        body
-      });
+      return error
+        ? reject(error)
+        : resolve({
+            response,
+            body
+          });
     });
   });
 }
@@ -73,7 +77,7 @@ function del(resource, headers) {
 function patch(resource, data, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: 'PATCH',
+      method: "PATCH",
       uri: resource,
       body: data,
       headers,
@@ -82,10 +86,12 @@ function patch(resource, data, headers) {
     };
 
     request(options, function(error, response, body) {
-      return error ? reject(error) : resolve({
-        response,
-        body
-      });
+      return error
+        ? reject(error)
+        : resolve({
+            response,
+            body
+          });
     });
   });
 }
@@ -93,6 +99,6 @@ function patch(resource, data, headers) {
 module.exports = {
   post,
   get,
-  'delete': del,
+  delete: del,
   patch
 };

--- a/http.js
+++ b/http.js
@@ -6,16 +6,16 @@
  *
  */
 
-const request = require("request");
+const request = require('request');
 
 function post(resource, data, headers) {
   headers = headers || {
-    "Content-Type": "application/json"
+    'Content-Type': 'application/json'
   };
 
   return new Promise(function(resolve, reject) {
     const options = {
-      method: "POST",
+      method: 'POST',
       uri: resource,
       body: data,
       headers,
@@ -37,7 +37,7 @@ function post(resource, data, headers) {
 function get(resource, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: "GET",
+      method: 'GET',
       uri: resource,
       headers,
       json: true
@@ -57,7 +57,7 @@ function get(resource, headers) {
 function del(resource, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: "DELETE",
+      method: 'DELETE',
       uri: resource,
       headers,
       json: true
@@ -77,7 +77,7 @@ function del(resource, headers) {
 function patch(resource, data, headers) {
   return new Promise(function(resolve, reject) {
     const options = {
-      method: "PATCH",
+      method: 'PATCH',
       uri: resource,
       body: data,
       headers,

--- a/jest.config.js
+++ b/jest.config.js
@@ -58,9 +58,7 @@ module.exports = {
   // globals: {},
 
   // An array of directory names to be searched recursively up from the requiring module's location
-  moduleDirectories: [
-    'node_modules'
-  ],
+  moduleDirectories: ["node_modules"],
 
   // An array of file extensions your modules use
   // moduleFileExtensions: [
@@ -104,7 +102,7 @@ module.exports = {
   // restoreMocks: false,
 
   // The root directory that Jest should scan for tests and modules within
-  rootDir: '.',
+  rootDir: ".",
 
   // A list of paths to directories that Jest should use to search for files in
   // roots: [
@@ -124,7 +122,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: 'node',
+  testEnvironment: "node",
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {'--harmony': true},
@@ -134,10 +132,10 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    '**/__tests__/**/*.js?(x)',
-    '**/?(*.)+(spec|test).js?(x)',
-    '**/*_test.js'
-  ],
+    "**/__tests__/**/*.js?(x)",
+    "**/?(*.)+(spec|test).js?(x)",
+    "**/*_test.js"
+  ]
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -58,7 +58,7 @@ module.exports = {
   // globals: {},
 
   // An array of directory names to be searched recursively up from the requiring module's location
-  moduleDirectories: ["node_modules"],
+  moduleDirectories: ['node_modules'],
 
   // An array of file extensions your modules use
   // moduleFileExtensions: [
@@ -102,7 +102,7 @@ module.exports = {
   // restoreMocks: false,
 
   // The root directory that Jest should scan for tests and modules within
-  rootDir: ".",
+  rootDir: '.',
 
   // A list of paths to directories that Jest should use to search for files in
   // roots: [
@@ -122,7 +122,7 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: "node",
+  testEnvironment: 'node',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {'--harmony': true},
@@ -132,9 +132,9 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
-    "**/__tests__/**/*.js?(x)",
-    "**/?(*.)+(spec|test).js?(x)",
-    "**/*_test.js"
+    '**/__tests__/**/*.js?(x)',
+    '**/?(*.)+(spec|test).js?(x)',
+    '**/*_test.js'
   ]
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,15 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -106,6 +115,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -566,7 +581,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -691,7 +706,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "dev": true,
       "requires": {
@@ -709,7 +724,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -1085,6 +1100,59 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -1150,8 +1218,7 @@
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1190,6 +1257,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+      "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+      "dev": true,
+      "requires": {
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1251,6 +1341,12 @@
         }
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "debug": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
@@ -1270,6 +1366,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-is": {
@@ -1418,6 +1520,12 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1538,21 +1646,12 @@
       "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
-      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz",
+      "integrity": "sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==",
       "dev": true,
       "requires": {
-        "fast-diff": "^1.1.1",
-        "jest-docblock": "^21.0.0"
-      },
-      "dependencies": {
-        "jest-docblock": {
-          "version": "21.2.0",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-          "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-          "dev": true
-        }
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-scope": {
@@ -1666,6 +1765,12 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1756,9 +1861,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-extend": {
@@ -1834,6 +1939,12 @@
         "repeat-element": "^1.1.2",
         "repeat-string": "^1.5.2"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -2454,6 +2565,18 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz",
+      "integrity": "sha512-CIJYJC4GGF06TakLg8z4GQKvDsx9EMspVxOYih7LerEL/WosUnFIww45CGfxfeKHqlg3twgUrYRT1O3WQqjGCg==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -2729,6 +2852,137 @@
         "sshpk": "^1.7.0"
       }
     },
+    "husky": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-1.1.2.tgz",
+      "integrity": "sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.6",
+        "execa": "^0.9.0",
+        "find-up": "^3.0.0",
+        "get-stdin": "^6.0.0",
+        "is-ci": "^1.2.1",
+        "pkg-dir": "^3.0.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^4.0.1",
+        "run-node": "^1.0.0",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
+          "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+          "dev": true,
+          "requires": {
+            "normalize-package-data": "^2.3.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2758,6 +3012,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
       "dev": true
     },
     "inflight": {
@@ -2835,7 +3095,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2890,6 +3150,12 @@
           "dev": true
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2955,6 +3221,21 @@
       "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
       }
     },
     "is-path-cwd": {
@@ -3024,6 +3305,12 @@
       "requires": {
         "has": "^1.0.1"
       }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -3660,6 +3947,12 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3745,9 +4038,566 @@
         "type-check": "~0.3.2"
       }
     },
+    "lint-staged": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz",
+      "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^5.0.2",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "execa": "^0.9.0",
+        "find-parent-dir": "^0.3.0",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "jest-validate": "^23.5.0",
+        "listr": "^0.14.1",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
+        "staged-git-files": "1.1.1",
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "listr": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.2.tgz",
+      "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.4.0",
+        "listr-verbose-renderer": "^0.4.0",
+        "p-map": "^1.1.1",
+        "rxjs": "^6.1.0"
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^1.0.2",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-cursor": "^1.0.2",
+        "date-fns": "^1.27.2",
+        "figures": "^1.7.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -3779,6 +4629,58 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        }
+      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -3839,9 +4741,9 @@
       }
     },
     "memfs": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.9.4.tgz",
-      "integrity": "sha512-wstvgqSTBGf9rQHoaRpX3wJiGzB/sj649XaO+byuHiPZQaR3Y/mOgU6n9iMFLtAHlR4BwwBWFgA4hobiU6EcCg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-2.10.1.tgz",
+      "integrity": "sha512-CXfNuf6TeF4ByYJ/cAxVcR2y58Q511soYd6JhXAJVPYp+9kIbkJZ+FZUw8fQCcNn5+XUNJ38CdjX0gpeUt5ITA==",
       "dev": true,
       "requires": {
         "fast-extend": "0.0.2",
@@ -3914,7 +4816,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -3941,7 +4843,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4057,6 +4959,15 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4064,6 +4975,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "number-is-nan": {
@@ -4268,6 +5190,12 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -4383,6 +5311,15 @@
         "find-up": "^2.1.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+      "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -4418,6 +5355,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
       "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "23.6.0",
@@ -4547,7 +5493,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4770,6 +5716,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
     },
     "rxjs": {
       "version": "6.3.3",
@@ -5101,7 +6053,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -5123,6 +6075,12 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
       "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "set-blocking": {
@@ -5428,6 +6386,12 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+      "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -5453,6 +6417,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
       "dev": true
     },
     "string-length": {
@@ -5482,6 +6452,17 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -5522,6 +6503,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -5570,7 +6557,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5899,7 +6886,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5971,7 +6958,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -6071,7 +7058,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "ajv": "^6.5.2",
     "eslint": "^5.6.0",
     "eslint-config-tamia": "^6.0.1",
-    "eslint-plugin-prettier": "^2.6.2",
+    "eslint-plugin-prettier": "^3.0.0",
+    "husky": "^1.1.0",
     "jest": "^23.6.0",
-    "memfs": "2.9.4",
+    "lint-staged": "^7.3.0",
+    "memfs": "2.10.1",
     "prettier": "^1.14.2"
   },
   "engines": {
@@ -22,7 +24,21 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "lint": "eslint . --cache --fix"
+    "lint": "eslint . --cache --fix",
+    "precommit": "lint-staged",
+    "prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "prettier --parser flow --write",
+      "git add"
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:coverage": "jest --coverage",
     "lint": "eslint . --cache --fix",
     "precommit": "lint-staged",
-    "prettier": "prettier --single-quote --trailing-comma es5 --write **/*.js *.js"
+    "prettier": "prettier --single-quote --parser flow --write **/*.js *.js"
   },
   "husky": {
     "hooks": {
@@ -36,7 +36,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "prettier --parser flow --write",
+      "prettier --single-quote --parser flow --write",
       "git add"
     ]
   },


### PR DESCRIPTION
Aligning this with the changes made to the Data Models repo.

I've update ESLint and added Husky and Lint-Staged so that whenever new JS files are staged they are linted and autoformatted. This eliminates the :poop: from reaching the repo.

I've also re-run prettier to ensure all the files are up to date.
