### PR TITLE
bug/incoming-@context-rules-not-creation-@context

### DIFF
--- a/contextConsumption/query_entities_test.js
+++ b/contextConsumption/query_entities_test.js
@@ -188,7 +188,7 @@ describe('Query Entity. JSON. Default @context', () => {
   it('query by condition over object', async function() {
     const queryParams = {
       type: entity.type,
-      q: 'R100==urn:ngsi-ld:T2:6789'
+      q: 'R100=="urn:ngsi-ld:T2:6789"'
     };
         
     const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));

--- a/contextConsumption/query_entities_test.js
+++ b/contextConsumption/query_entities_test.js
@@ -80,7 +80,8 @@ describe('Query Entity. JSON. Default @context', () => {
   
   it('query by attributes.', async function() {
     const queryParams = {
-      attrs: 'P100',
+      type: 'T_Query',
+      attrs: 'P100'
     };
             
     const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));
@@ -187,7 +188,7 @@ describe('Query Entity. JSON. Default @context', () => {
   it('query by condition over object', async function() {
     const queryParams = {
       type: entity.type,
-      q: 'R100=="urn:ngsi-ld:T2:6789"'
+      q: 'R100==urn:ngsi-ld:T2:6789'
     };
         
     const response = await http.get(entitiesResource + '?' + serializeParams(queryParams));

--- a/contextConsumption/retrieve_entity_with_ldcontext_test.js
+++ b/contextConsumption/retrieve_entity_with_ldcontext_test.js
@@ -90,17 +90,28 @@ describe('Retrieve Entity. JSON-LD. @context ', () => {
   });
   
   it('should retrieve the entity. JSON-LD MIME Type requested', async function() {
-    const response = await http.get(entitiesResource + entityId, JSON_LD_HEADERS_GET);
+    const headers = {
+      'Accept': 'application/ld+json',
+      'Link': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    };
+    const response = await http.get(entitiesResource + entityId, headers);
     assertRetrieved(response,entity, JSON_LD);
   });
     
   it('should retrieve the entity. JSON MIME type (default)', async function() {
-    const response = await http.get(entitiesResource + entityId);
+    const headers = {
+      'Link': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    };
+    const response = await http.get(entitiesResource + entityId, headers);
     assertRetrieved(response,entityNoContext);
   });
     
   it('should retrieve the entity key values mode', async function() {
-    const response = await http.get(entitiesResource + entityId + '?options=keyValues', JSON_LD_HEADERS_GET);
+    const headers = {
+      'Accept': 'application/ld+json',
+      'Link': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    };
+    const response = await http.get(entitiesResource + entityId + '?options=keyValues', headers);
     assertRetrieved(response,entityKeyValues,JSON_LD);
   });
     
@@ -128,6 +139,12 @@ describe('Retrieve Entity. JSON-LD. @context ', () => {
       // Observe that the provided @context will make the attribute not to match
       'Link': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
     };
+    const expectedEntityNoAttr = {
+    'id': entity.id,
+    'type': 'http://example.org/T'
+    '@context': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+  };
+    
     const response = await http.get(entitiesResource + entityId + '?attrs=P1', headers);
     assertRetrieved(response,entityNoAttr, JSON_LD);
   });

--- a/contextConsumption/retrieve_entity_with_ldcontext_test.js
+++ b/contextConsumption/retrieve_entity_with_ldcontext_test.js
@@ -141,12 +141,12 @@ describe('Retrieve Entity. JSON-LD. @context ', () => {
     };
     const expectedEntityNoAttr = {
     'id': entity.id,
-    'type': 'http://example.org/T'
-    '@context': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext2.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    'type': 'http://example.org/T',
+    '@context': 'https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testContext2.jsonld'
   };
     
     const response = await http.get(entitiesResource + entityId + '?attrs=P1', headers);
-    assertRetrieved(response,entityNoAttr, JSON_LD);
+    assertRetrieved(response, expectedEntityNoAttr, JSON_LD);
   });
   
 });

--- a/contextConsumption/retrieve_entity_with_ldcontext_test.js
+++ b/contextConsumption/retrieve_entity_with_ldcontext_test.js
@@ -10,10 +10,6 @@ const JSON_LD_HEADERS_POST = {
   'Content-Type': 'application/ld+json'
 };
 
-const JSON_LD_HEADERS_GET = {
-  'Accept': 'application/ld+json'
-};
-
 // Patches the object and returns a new copy of the patched object
 // TECHNICAL DEBT: It should be imported from common.js
 function patchObj(target, patch) {  

--- a/contextSubscription/retrieve_subscription_with_ldcontext_test.js
+++ b/contextSubscription/retrieve_subscription_with_ldcontext_test.js
@@ -53,7 +53,11 @@ describe('Retrieve Subscription. JSON-LD. @context', () => {
   });
     
   it('should retrieve the subscription', async function() {
-    const response = await http.get(subscriptionsResource + subscriptionId, JSON_LD_HEADERS_GET);
+    const headers = {
+      'Accept': 'application/ld+json',
+      'Link': '<https://fiware.github.io/NGSI-LD_TestSuite/ldContext/testFullContext.jsonld>; rel="http://www.w3.org/ns/json-ld#context"; type="application/ld+json"'
+    };
+    const response = await http.get(subscriptionsResource + subscriptionId, headers);
     assertRetrieved(response, subscription, JSON_LD);
   });
     


### PR DESCRIPTION
Modified a few incorrect tests:
1. Two simple bugs (query_entities_test.js and retrieve_entity_with_ldcontext_test.js)
2. Five test cases needed to supply the @context that was used during the creation of the Entity.

(2) Explained:
We had an old conviction that the @context that an entity was created with should be used in later GET operations of an entity.
After some thinking we understood this was a very bad idea.
The @context of the incoming GET operation (or whatever operation) is the @context to use when performing the "long name to alias" conversion.

This PR simply adds the "correct" @context to some GET requests, i.e.m the same @context that was used during creation of an entity is also used during GET operations.
This was the easiest way of making the test cases correct.