### PR TITLE
Task/registation with orion api v2 data model

### DIFF
--- a/contextSourceRegistration/create_csource_registration_test.js
+++ b/contextSourceRegistration/create_csource_registration_test.js
@@ -16,13 +16,7 @@ describe("Create Registration. JSON", () => {
             {
               'id': 'urn:ngsi-ld:Vehicle:A456',
               'type': 'Vehicle'
-            }
-          ],
-          'properties': ['brandName', 'speed'],
-          'relationships': ['isParked']
-        },
-        {
-          'entities': [
+            },
             {
               'idPattern': '.*downtown$',
               'type': 'OffStreetParking'
@@ -32,8 +26,8 @@ describe("Create Registration. JSON", () => {
               'type': 'OffStreetParking'
             }
           ],
-          'properties': ['availableSotNumber', 'totalSpotNumber'],
-          'relationships': ['isNextToBuilding']
+          'properties': ['brandName', 'speed', 'availableSpotNumber', 'totalSpotNumber'],
+          'relationships': ['isParked', 'isNextToBuilding']
         }
       ],
       'endpoint': 'http://my.csource.org:1026',


### PR DESCRIPTION
Changed the "information" vector of the registration to have only one member.

Orionld uses the data model of orion and this datamodel don't allow for more than one item in the "information" vector :(

Some day (not soon) this will be fixed in orionld but until then it would be good to test what the broker is able to do, not things that will come far from soon ...