### PR TITLE
Fixed a few errors in test suite

### DIFF
--- a/contextConsumption/name_prefix_test.js
+++ b/contextConsumption/name_prefix_test.js
@@ -109,13 +109,13 @@ describe('Name prefixes test', () => {
 
         const response = await http.get(entitiesResource + '?' + serializeParams(queryParams), headers);
         expect(response.body[0]).toBeDefined();
-        expect(response.body[0]).toHaveProperty('schema:name.value', 'XX');
+        expect(response.body[0]).toHaveProperty('name.value', 'XX');
     });
 
     it('query by condition over prefixed attribute. Right @context. ', async function() {
         const queryParams = {
             type: 'http://example.org/T_Query',
-            q: 'schema:name==XX'
+            q: 'schema:name=="XX"'
         };
 
         const headers = {
@@ -130,7 +130,7 @@ describe('Name prefixes test', () => {
     it('query by condition over prefixed attribute. No @context. ', async function() {
         const queryParams = {
             type: 'http://example.org/T_Query',
-            q: 'schema:name==XX'
+            q: 'schema:name=="XX"'
         };
 
         const headers = {


### PR DESCRIPTION
1. schema:name ... the prefix 'schema' is replaced by 'https://schema.org/name' or similar, and stored like that in DB.
    On a subsequent GET with schema @context, 'https://schema.org/name' is compacted to 'name' - according to the @context!   The test in erroneous. No way to get back to "schems:name".
    If you need further explanation, i'm happy to explain.

2. 'schema:name=="XX"' - the double quotes were missing - another error in the test suite

   