### PR TITLE
Fixed a few bugs in the test suite

### DIFF
--- a/contextProvision/append_entity_attrs_test.js
+++ b/contextProvision/append_entity_attrs_test.js
@@ -112,7 +112,7 @@ describe('Append Entity Attributes. JSON. Default @context', () => {
             }
         };
         const response = await http.post(entitiesResource + entityId + '/attrs/?options=noOverwrite', overwrittenAttrs);
-        expect(response.response).toHaveProperty('statusCode', 204);
+        expect(response.response).toHaveProperty('statusCode', 207);
 
         const finalEntity = patchObj(entity, {});
         finalEntity.P2 = overwrittenAttrs.P2;

--- a/contextProvision/append_entity_attrs_with_ldcontext_test.js
+++ b/contextProvision/append_entity_attrs_with_ldcontext_test.js
@@ -19,7 +19,7 @@ function patchObj(target, patch) {
 }
 
 describe('Append Entity Attributes. JSON-LD @context', () => {
-    entity = {
+    let entity = {
         id: 'urn:ngsi-ld:T:' + new Date().getTime(),
         type: 'T',
         P1: {

--- a/contextProvision/append_entity_attrs_with_ldcontext_test.js
+++ b/contextProvision/append_entity_attrs_with_ldcontext_test.js
@@ -19,7 +19,7 @@ function patchObj(target, patch) {
 }
 
 describe('Append Entity Attributes. JSON-LD @context', () => {
-    const entity = {
+    entity = {
         id: 'urn:ngsi-ld:T:' + new Date().getTime(),
         type: 'T',
         P1: {
@@ -88,8 +88,8 @@ describe('Append Entity Attributes. JSON-LD @context', () => {
 
         const checkResponse = await http.get(`${entitiesResource}${entityId}`, ACCEPT_LD);
 
-        const finalEntity = patchObj(entity, appendedAttributes);
-        expect(checkResponse.body).toEqual(finalEntity);
+        entity = patchObj(entity, appendedAttributes);
+        expect(checkResponse.body).toEqual(entity);
     });
 
     it('append Entity Attributes. Attributes are overwritten 080', async function() {
@@ -104,8 +104,8 @@ describe('Append Entity Attributes. JSON-LD @context', () => {
         expect(response.response).toHaveProperty('statusCode', 204);
 
         const checkResponse = await http.get(`${entitiesResource}${entityId}`, ACCEPT_LD);
-        const finalEntity = patchObj(entity, overwrittenAttrs);
-        expect(checkResponse.body).toEqual(finalEntity);
+        entity = patchObj(entity, overwrittenAttrs);
+        expect(checkResponse.body).toEqual(entity);
     });
 
     it('append Entity Attributes. Attributes should not be overwritten. Partial success 081', async function() {
@@ -127,9 +127,8 @@ describe('Append Entity Attributes. JSON-LD @context', () => {
         );
         expect(response.response).toHaveProperty('statusCode', 207);
 
-        const finalEntity = patchObj(entity, {});
-        finalEntity.P2 = overwrittenAttrs.P2;
+        entity.P2 = overwrittenAttrs.P2;
         const checkResponse = await http.get(entitiesResource + entityId, ACCEPT_LD);
-        expect(checkResponse.body).toEqual(finalEntity);
+        expect(checkResponse.body).toEqual(entity);
     });
 });


### PR DESCRIPTION
Test case 079 changes the entity (in the broker)
But, the test case 080 compares using the initial entity (before 079 was applied) adding whatever was changed in 080.
Same same in 081.

What I did was to make the variable 'entity' non-const and let it change according to each test case.
